### PR TITLE
Add tests key to request node

### DIFF
--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -11,6 +11,7 @@ class RequestNode(EndpointNode):
         self.method = self.spec["method"]
         self.body = self.define_body()
         self.id = self.define_id()
+        self.tests = self.define_tests()
 
         self.api_tree.save_custom_vars(self.spec)
 
@@ -25,6 +26,12 @@ class RequestNode(EndpointNode):
             return
 
         return self.spec_evaluator.evaluate(self.spec["body"])
+
+    def define_tests(self):
+        if "tests" not in self.spec:
+            return
+
+        return self.spec["tests"]
 
     def define_id(self):
         if not self.namespace:

--- a/scanapi/tree/tree_keys.py
+++ b/scanapi/tree/tree_keys.py
@@ -9,6 +9,7 @@ PATH_KEY = "path"
 PARAMS = "params"
 REQUESTS_KEY = "requests"
 VARS_KEY = "vars"
+TESTS_KEY = "tests"
 
 ROOT_NODE_KEYS = (BASE_URL_KEY, ENDPOINTS_KEY, HEADERS_KEY, PARAMS, REQUESTS_KEY)
 
@@ -29,4 +30,5 @@ REQUEST_NODE_KEYS = (
     PARAMS,
     PATH_KEY,
     VARS_KEY,
+    TESTS_KEY,
 )

--- a/tests/data/specs/with_endpoints/get_with_header_body_params.yaml
+++ b/tests/data/specs/with_endpoints/get_with_header_body_params.yaml
@@ -16,3 +16,5 @@ api:
             page: 0
           body:
             bodeKey: abc
+          tests:
+            - status_code_is_200: response.status_code == 200

--- a/tests/data/specs/with_endpoints/minimal_get.yaml
+++ b/tests/data/specs/with_endpoints/minimal_get.yaml
@@ -6,3 +6,5 @@ api:
       requests:
         - name: list_all_posts
           method: get
+          tests:
+            - status_code_is_200: response.status_code == 200

--- a/tests/data/specs/with_multiple_tests.yaml
+++ b/tests/data/specs/with_multiple_tests.yaml
@@ -1,11 +1,5 @@
 api:
   base_url: https://jsonplaceholder.typicode.com/
-  requests:
-    - name: docs
-      method: get
-      path: docs
-      tests:
-        - status_code_is_200: response.status_code == 200
   endpoints:
     - namespace: posts
       path: /posts
@@ -14,3 +8,4 @@ api:
           method: get
           tests:
             - status_code_is_200: response.status_code == 200
+            - status_code_is_not_201: response.status_code != 201

--- a/tests/data/specs/without_endpoints/minimal_get.yaml
+++ b/tests/data/specs/without_endpoints/minimal_get.yaml
@@ -4,3 +4,5 @@ api:
     - name: list_all_posts
       path: /posts
       method: get
+      tests:
+        - status_code_is_200: response.status_code == 200

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -20,6 +20,7 @@ WITH_ENDPOINTS_GET_WITH_HEADER_BODY_PARAMS = load_yaml(
 WITHOUT_ENDPOINTS_MINIMAL_SPEC = load_yaml(
     "tests/data/specs/without_endpoints/minimal_get.yaml"
 )
+WITH_MULTIPLE_TESTS = load_yaml("tests/data/specs/with_multiple_tests.yaml")
 METHOD_NOT_ALLOWED_SPEC = load_yaml("tests/data/specs/invalid/method_not_allowed.yaml")
 
 
@@ -40,6 +41,7 @@ class APITreeFactory(factory.Factory):
         without_endpoints_minimal = factory.Trait(
             api_spec=WITHOUT_ENDPOINTS_MINIMAL_SPEC
         )
+        with_multiple_tests = factory.Trait(api_spec=WITH_MULTIPLE_TESTS)
         method_not_allowed = factory.Trait(api_spec=METHOD_NOT_ALLOWED_SPEC)
 
 

--- a/tests/unit/tree/test_api_tree.py
+++ b/tests/unit/tree/test_api_tree.py
@@ -31,7 +31,11 @@ class TestAPITree:
             request = api_tree.request_nodes[0]
 
             assert len(api_tree.request_nodes) == 1
-            assert request.spec == {"name": "list_all_posts", "method": "get"}
+            assert request.spec == {
+                "name": "list_all_posts",
+                "method": "get",
+                "tests": [{"status_code_is_200": "response.status_code == 200"}],
+            }
             assert request.id == "posts_list_all_posts"
             assert request.url == "https://jsonplaceholder.typicode.com/posts"
             assert request.method == "get"
@@ -53,6 +57,7 @@ class TestAPITree:
                 "name": "list_all_posts",
                 "path": "/posts",
                 "method": "get",
+                "tests": [{"status_code_is_200": "response.status_code == 200"}],
             }
             assert len(api_tree.request_nodes) == 1
             assert request.id == "list_all_posts"
@@ -79,6 +84,7 @@ class TestAPITree:
                 "name": "docs",
                 "method": "get",
                 "path": "docs",
+                "tests": [{"status_code_is_200": "response.status_code == 200"}],
             }
             assert root_request.id == "docs"
             assert root_request.url == "https://jsonplaceholder.typicode.com/docs"
@@ -87,7 +93,11 @@ class TestAPITree:
             assert root_request.headers is None
 
             endpoint_request = api_tree.request_nodes[1]
-            assert endpoint_request.spec == {"name": "list_all_posts", "method": "get"}
+            assert endpoint_request.spec == {
+                "name": "list_all_posts",
+                "method": "get",
+                "tests": [{"status_code_is_200": "response.status_code == 200"}],
+            }
             assert endpoint_request.id == "posts_list_all_posts"
             assert endpoint_request.url == "https://jsonplaceholder.typicode.com/posts"
             assert endpoint_request.method == "get"

--- a/tests/unit/tree/test_api_tree.py
+++ b/tests/unit/tree/test_api_tree.py
@@ -9,113 +9,87 @@ from tests.unit.factories import (
 
 
 class TestAPITree:
-    class TestBuild:
-        @pytest.fixture
-        def mock_build_endpoints(self, mocker):
-            return mocker.patch("scanapi.tree.api_tree.APITree.build_endpoints")
+    @pytest.fixture
+    def mock_build_endpoints(self, mocker):
+        return mocker.patch("scanapi.tree.api_tree.APITree.build_endpoints")
 
-        @pytest.fixture
-        def mock_build_requests(self, mocker):
-            return mocker.patch("scanapi.tree.api_tree.APITree.build_requests")
+    @pytest.fixture
+    def mock_build_requests(self, mocker):
+        return mocker.patch("scanapi.tree.api_tree.APITree.build_requests")
 
-        class TestWhenSpecHasEndpoints:
-            @pytest.fixture
-            def api_tree(self):
-                return APITreeFactory(with_endpoints_minimal=True)
+    class TestWhenSpecHasEndpointsAndNoRootRequests:
+        def test_build_endpoints_should_be_called(
+            self, mock_build_endpoints, mock_build_requests
+        ):
+            APITreeFactory(api_spec=WITH_ENDPOINTS_MINIMAL_SPEC)
 
-            @pytest.fixture
-            def api_spec(self):
-                return WITH_ENDPOINTS_MINIMAL_SPEC
+            assert mock_build_endpoints.called_once
+            assert not mock_build_requests.called
 
-            def test_should_build_requests(self, api_tree):
-                request = api_tree.request_nodes[0]
-                assert len(api_tree.request_nodes) == 1
-                assert request.spec == {"name": "list_all_posts", "method": "get"}
-                assert request.id == "posts_list_all_posts"
-                assert request.url == "https://jsonplaceholder.typicode.com/posts"
-                assert request.method == "get"
-                assert request.body is None
-                assert request.headers is None
+        def test_should_build_requests(self):
+            api_tree = APITreeFactory(with_endpoints_minimal=True)
+            request = api_tree.request_nodes[0]
 
-            def test_build_endpoints_should_be_called(
-                self, api_spec, mock_build_endpoints, mock_build_requests
-            ):
-                APITreeFactory(api_spec=api_spec)
+            assert len(api_tree.request_nodes) == 1
+            assert request.spec == {"name": "list_all_posts", "method": "get"}
+            assert request.id == "posts_list_all_posts"
+            assert request.url == "https://jsonplaceholder.typicode.com/posts"
+            assert request.method == "get"
+            assert request.body is None
+            assert request.headers is None
 
-                assert mock_build_endpoints.called_once
-                assert not mock_build_requests.called
+    class TestWhenSpecHasRootRequestsAndDoesNotHaveEndpoints:
+        def test_build_request_should_be_called(
+            self, mock_build_endpoints, mock_build_requests
+        ):
+            APITreeFactory(api_spec=WITHOUT_ENDPOINTS_MINIMAL_SPEC)
+            assert mock_build_requests.called_once
 
-        class TestWhenSpecDoesNotHaveEndpoints:
-            @pytest.fixture
-            def api_tree(self):
-                return APITreeFactory(without_endpoints_minimal=True)
+        def test_should_build_requests(self):
+            api_tree = APITreeFactory(without_endpoints_minimal=True)
+            request = api_tree.request_nodes[0]
 
-            @pytest.fixture
-            def api_spec(self):
-                return WITHOUT_ENDPOINTS_MINIMAL_SPEC
+            assert request.spec == {
+                "name": "list_all_posts",
+                "path": "/posts",
+                "method": "get",
+            }
+            assert len(api_tree.request_nodes) == 1
+            assert request.id == "list_all_posts"
+            assert request.url == "https://jsonplaceholder.typicode.com/posts"
+            assert request.method == "get"
+            assert request.body is None
+            assert request.headers is None
 
-            def test_should_build_requests(self, api_tree):
-                request = api_tree.request_nodes[0]
+    class TestWhenSpecHasRootRequestAndEndpoints:
+        def test_build_request_should_be_called(
+            self, mock_build_endpoints, mock_build_requests
+        ):
+            APITreeFactory(api_spec=WITH_ENDPOINTS_WITH_ROOT_REQUESTS)
 
-                assert len(api_tree.request_nodes) == 1
-                assert request.spec == {
-                    "name": "list_all_posts",
-                    "path": "/posts",
-                    "method": "get",
-                }
-                assert request.id == "list_all_posts"
-                assert request.url == "https://jsonplaceholder.typicode.com/posts"
-                assert request.method == "get"
-                assert request.body is None
-                assert request.headers is None
+            assert mock_build_requests.called_once
+            assert mock_build_requests.called_once
 
-            def test_build_request_should_be_called(
-                self, api_spec, mock_build_endpoints, mock_build_requests
-            ):
-                APITreeFactory(api_spec=api_spec)
-                assert mock_build_requests.called_once
+        def test_should_build_requests(self):
+            api_tree = APITreeFactory(with_endpoints_with_root_requests=True)
+            root_request = api_tree.request_nodes[0]
 
-        class TestWhenSpecHasRootRequestAndEndpoints:
-            @pytest.fixture
-            def api_tree(self):
-                return APITreeFactory(with_endpoints_with_root_requests=True)
+            assert len(api_tree.request_nodes) == 2
+            assert root_request.spec == {
+                "name": "docs",
+                "method": "get",
+                "path": "docs",
+            }
+            assert root_request.id == "docs"
+            assert root_request.url == "https://jsonplaceholder.typicode.com/docs"
+            assert root_request.method == "get"
+            assert root_request.body is None
+            assert root_request.headers is None
 
-            @pytest.fixture
-            def api_spec(self):
-                return WITH_ENDPOINTS_WITH_ROOT_REQUESTS
-
-            def test_should_build_requests(self, api_tree):
-                assert len(api_tree.request_nodes) == 2
-
-                root_request = api_tree.request_nodes[0]
-                assert root_request.spec == {
-                    "name": "docs",
-                    "method": "get",
-                    "path": "docs",
-                }
-                assert root_request.id == "docs"
-                assert root_request.url == "https://jsonplaceholder.typicode.com/docs"
-                assert root_request.method == "get"
-                assert root_request.body is None
-                assert root_request.headers is None
-
-                endpoint_request = api_tree.request_nodes[1]
-                assert endpoint_request.spec == {
-                    "name": "list_all_posts",
-                    "method": "get",
-                }
-                assert endpoint_request.id == "posts_list_all_posts"
-                assert (
-                    endpoint_request.url == "https://jsonplaceholder.typicode.com/posts"
-                )
-                assert endpoint_request.method == "get"
-                assert endpoint_request.body is None
-                assert endpoint_request.headers is None
-
-            def test_build_request_should_be_called(
-                self, api_spec, mock_build_endpoints, mock_build_requests
-            ):
-                APITreeFactory(api_spec=api_spec)
-
-                assert mock_build_requests.called_once
-                assert mock_build_requests.called_once
+            endpoint_request = api_tree.request_nodes[1]
+            assert endpoint_request.spec == {"name": "list_all_posts", "method": "get"}
+            assert endpoint_request.id == "posts_list_all_posts"
+            assert endpoint_request.url == "https://jsonplaceholder.typicode.com/posts"
+            assert endpoint_request.method == "get"
+            assert endpoint_request.body is None
+            assert endpoint_request.headers is None

--- a/tests/unit/tree/test_request_node.py
+++ b/tests/unit/tree/test_request_node.py
@@ -1,0 +1,19 @@
+from tests.unit.factories import APITreeFactory
+
+
+class TestRequestNode:
+    class TestDefineTests:
+        def test_should_define_tests(self):
+            api = APITreeFactory(with_endpoints_with_root_requests=True)
+            for request_node in api.request_nodes:
+                assert request_node.tests == [
+                    {"status_code_is_200": "response.status_code == 200"}
+                ]
+
+        def test_should_define_multiple_tests(self):
+            api = APITreeFactory(with_multiple_tests=True)
+            request_node = api.request_nodes[0]
+            assert request_node.tests == [
+                {"status_code_is_200": "response.status_code == 200"},
+                {"status_code_is_not_201": "response.status_code != 201"},
+            ]


### PR DESCRIPTION
## Description

- [x] Refactor APITree tests
- [x] Add tests key to request node

## Example

```yaml
api:
  base_url: https://jsonplaceholder.typicode.com/
  endpoints:
    - namespace: posts
      path: /posts
      requests:
        - name: list_all_posts
          method: get
          tests:
            - status_code_is_200: response.status_code == 200
```

Part of #11 