### PR TITLE
Update codecov badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://user-images.githubusercontent.com/2728804/73694724-6d019080-46b7-11ea-8960-70db8f9b0a29.png"/>
 
 [![CircleCI](https://circleci.com/gh/scanapi/scanapi.svg?style=svg)](https://circleci.com/gh/scanapi/scanapi)
-[![codecov](https://codecov.io/gh/camilamaia/scanapi/branch/master/graph/badge.svg)](https://codecov.io/gh/camilamaia/scanapi)
+[![codecov](https://codecov.io/gh/scanapi/scanapi/branch/master/graph/badge.svg)](https://codecov.io/gh/scanapi/scanapi)
 [![PyPI version](https://badge.fury.io/py/scanapi.svg)](https://badge.fury.io/py/scanapi)
 [![Gitter chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scanapi/community)
 


### PR DESCRIPTION
## Description

Update codecov badge links to use `/scanapi/scanapi` instead of `/camilamaia/scanapi`