### PR TITLE
Move black check to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,28 +7,6 @@ executors:
       - image: circleci/golang:1.9.6
 
 jobs:
-  check-black:
-    docker:
-      - image: circleci/python:3.7.3
-    steps:
-      - checkout
-      - restore_cache:
-          key: v3-python-requirements-black
-      - run:
-          name: Install Black
-          command: |
-            virtualenv ~/venv-black
-            . ~/venv-black/bin/activate
-            pip install black==19.10b0
-      - save_cache:
-          key: v3-python-requirements-black
-          paths:
-            - "~/venv-black"
-      - run:
-          name: Run Black check
-          command: |
-            . ~/venv-black/bin/activate
-            black --check .
   changelog-lint:
     executor: changelog-linter
     steps:
@@ -71,6 +49,5 @@ workflows:
   version: 2
   master:
     jobs:
-      - check-black
       - changelog-lint
       - build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+on: pull_request
+name: Lint check
+jobs:
+  black:
+    name: Lint check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: "Black Code Formatter"
+        uses: "lgeiger/black-action@v1.0.1"
+        with:
+          args: ". --check"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `namespace` keyword to `name` [#116](https://github.com/scanapi/scanapi/issues/116)
 - `method` keyword is not mandatory anymore for requests. Default is `get` [#116](https://github.com/scanapi/scanapi/issues/116)
 - Replaced `hide` key on report config by `hide-request` and `hide-response` [#116](https://github.com/scanapi/scanapi/issues/116)
+- Moved black check from CircleCI to github actions [#136](https://github.com/scanapi/scanapi/pull/136)
 
 ### Fixed
 - Cases where custom var has upper case letters [#99](https://github.com/scanapi/scanapi/issues/99)


### PR DESCRIPTION
## Description
Move black check from CircleCI to GitHub actions:

https://github.com/marketplace/actions/black-code-formatter

Closes #136 