### PR TITLE
Release v0.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.19] - 2020-05-11
 ### Added
 - PATCH HTTP method - [#77](https://github.com/scanapi/scanapi/issues/77)
 - Ability to have API spec in multiples files - [#125](https://github.com/scanapi/scanapi/issues/125)
@@ -86,7 +88,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v0.0.18...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v0.0.19...HEAD
+[0.0.19]: https://github.com/camilamaia/scanapi/compare/v0.0.18...v0.0.19
 [0.0.18]: https://github.com/camilamaia/scanapi/compare/v0.0.17...v0.0.18
 [0.0.17]: https://github.com/camilamaia/scanapi/compare/v0.0.16...v0.0.17
 [0.0.16]: https://github.com/camilamaia/scanapi/compare/v0.0.15...v0.0.16

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="scanapi",
-    version="0.0.18",
+    version="0.0.19",
     author="Camila Maia",
     author_email="cmaiacd@gmail.com",
     description="Automated Testing and Documentation for your REST API",


### PR DESCRIPTION
## Description

### Added
- PATCH HTTP method - [#77](https://github.com/scanapi/scanapi/issues/77)
- Ability to have API spec in multiples files - [#125](https://github.com/scanapi/scanapi/issues/125)
- CLI `--config-path` option - [#128](https://github.com/scanapi/scanapi/issues/128)
- CLI `--template-path` option - [#126](https://github.com/scanapi/scanapi/pull/126)
- GitHub Action checking for missing changelog entry - [#134](https://github.com/scanapi/scanapi/pull/134)

### Changed
- Make markdown report a bit better - [#96](https://github.com/scanapi/scanapi/issues/96)
- `base_url` keyword to `path` [#116](https://github.com/scanapi/scanapi/issues/116)
- `namespace` keyword to `name` [#116](https://github.com/scanapi/scanapi/issues/116)
- `method` keyword is not mandatory anymore for requests. Default is `get` [#116](https://github.com/scanapi/scanapi/issues/116)
- Replaced `hide` key on report config by `hide-request` and `hide-response` [#116](https://github.com/scanapi/scanapi/issues/116)
- Moved black check from CircleCI to github actions [#136](https://github.com/scanapi/scanapi/pull/136)

### Fixed
- Cases where custom var has upper case letters [#99](https://github.com/scanapi/scanapi/issues/99)

### Removed
- Request with no endpoints [#116](https://github.com/scanapi/scanapi/issues/116)