### PR TITLE
Automated PyPI deploy with Github Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,32 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+on: push
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install pep517
+        run: >-
+          python -m
+          pip install
+          pep517
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          pep517.build
+          --source
+          --binary
+          --out-dir dist/
+          .
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,44 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Automated pypi deploy - [#144](https://github.com/scanapi/scanapi/pull/144)
 
 ## [0.0.19] - 2020-05-11
 ### Added
-- PATCH HTTP method - [#77](https://github.com/scanapi/scanapi/issues/77)
-- Ability to have API spec in multiples files - [#125](https://github.com/scanapi/scanapi/issues/125)
-- CLI `--config-path` option - [#128](https://github.com/scanapi/scanapi/issues/128)
+- PATCH HTTP method - [#113](https://github.com/scanapi/scanapi/pull/113)
+- Ability to have API spec in multiples files - [#125](https://github.com/scanapi/scanapi/pull/125)
+- CLI `--config-path` option - [#128](https://github.com/scanapi/scanapi/pull/128)
 - CLI `--template-path` option - [#126](https://github.com/scanapi/scanapi/pull/126)
 - GitHub Action checking for missing changelog entry - [#134](https://github.com/scanapi/scanapi/pull/134)
 
 ### Changed
-- Make markdown report a bit better - [#96](https://github.com/scanapi/scanapi/issues/96)
-- `base_url` keyword to `path` [#116](https://github.com/scanapi/scanapi/issues/116)
-- `namespace` keyword to `name` [#116](https://github.com/scanapi/scanapi/issues/116)
-- `method` keyword is not mandatory anymore for requests. Default is `get` [#116](https://github.com/scanapi/scanapi/issues/116)
-- Replaced `hide` key on report config by `hide-request` and `hide-response` [#116](https://github.com/scanapi/scanapi/issues/116)
+- Make markdown report a bit better - [#96](https://github.com/scanapi/scanapi/pull/96)
+- `base_url` keyword to `path` [#116](https://github.com/scanapi/scanapi/pull/116)
+- `namespace` keyword to `name` [#116](https://github.com/scanapi/scanapi/pull/116)
+- `method` keyword is not mandatory anymore for requests. Default is `get` [#116](https://github.com/scanapi/scanapi/pull/116)
+- Replaced `hide` key on report config by `hide-request` and `hide-response` [#116](https://github.com/scanapi/scanapi/pull/116)
 - Moved black check from CircleCI to github actions [#136](https://github.com/scanapi/scanapi/pull/136)
 
 ### Fixed
-- Cases where custom var has upper case letters [#99](https://github.com/scanapi/scanapi/issues/99)
+- Cases where custom var has upper case letters [#99](https://github.com/scanapi/scanapi/pull/99)
 
 ### Removed
-- Request with no endpoints [#116](https://github.com/scanapi/scanapi/issues/116)
+- Request with no endpoints [#116](https://github.com/scanapi/scanapi/pull/116)
 
 ## [0.0.18] - 2020-01-02
 ### Changed
-- Return params/headers None when request doesn't have params/headers [#87](https://github.com/scanapi/scanapi/issues/87)
+- Return params/headers None when request doesn't have params/headers [#87](https://github.com/scanapi/scanapi/pull/87)
 
 ### Fixed
-- Report-example image not loading on PyPi [#86](https://github.com/scanapi/scanapi/issues/86)
+- Report-example image not loading on PyPi [#86](https://github.com/scanapi/scanapi/pull/86)
 
 ## [0.0.17] - 2019-12-19
 ### Added
 - Added PyPI Test section to CONTRIBUTING.md
-- Added templates to pypi package - fix [#84](https://github.com/camilamaia/scanapi/issues/84)
+- Added templates to pypi package - fix [#85](https://github.com/scanapi/scanapi/pull/85)
 
 ## [0.0.16] - 2019-12-18
 ### Fixed
-- Fixed No module named 'scanapi.tree' [#82](https://github.com/camilamaia/scanapi/issues/82)
+- Fixed No module named 'scanapi.tree' [#83](https://github.com/scanapi/scanapi/pull/83)
 
 ## [0.0.15] - 2019-12-14
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,18 +36,10 @@ $ pytest --gherkin-terminal-reporter
 
 ## Deploy
 
-Requirements:
-
-- [setuptools][setuptools]
-- [twine][twine]
-- [PyPI Test][pypi-test] credentials
-- [PyPI][pypi] credentials
-
 Steps:
 1. Release PR
 2. Deploy on GitHub
-3. Deploy on PyPI
-4. Upgrade ScanAPI on ScanAPI Demo
+3. Upgrade ScanAPI on ScanAPI Demo
 
 ### 1. Release PR
 
@@ -68,6 +60,10 @@ Create a PR named `Release <version>` containing these two changes above.
 
 [Example of Release PR](https://github.com/camilamaia/scanapi/commit/86e89e6ab52bbf64e058c02dbfdbbb1500066bff)
 
+### Merge the PR
+
+Once the PR was accepted, merge it.
+
 ### 2. Deploy on GitHub
 
 Deploy on GitHub is done when a [new release is created][creating-releases].
@@ -78,41 +74,9 @@ Deploy on GitHub is done when a [new release is created][creating-releases].
 
 Real examples are available at: https://github.com/camilamaia/scanapi/releases.
 
-### 3. Deploy on PyPI
+When GitHub Deploy is done, the new version will be automatically deployed on Docker Hub and PyPI
 
-#### PyPI Test
-
-Before sending directly the new release to the official PyPi repository, it is a good practice to send it to [PyPI Test][pypi-test] first.
-
-For that, check the last release number at https://test.pypi.org/manage/project/scanapi/releases/
-Increment **locally** the version number at `setup.py` according to the version you have just got. Do not commit the `setup.py` changes.
-
-Run:
-
-```bash
-sudo rm -r dist/*
-python3 setup.py sdist bdist_wheel
-twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-```
-
-To install and test it, run:
-
-```bash
-$ pip install -i https://test.pypi.org/simple/ scanapi
-```
-
-**Revert the `setup.py` changes.**
-
-#### PyPi Production
-
-```bash
-$ cd scanapi
-$ rm -r dist/*
-$ python3 setup.py sdist bdist_wheel
-$ twine upload dist/*
-```
-
-### 4. Upgrade ScanAPI on ScanAPI Demo
+### 3. Upgrade ScanAPI on ScanAPI Demo
 
 Upgrade version of ScanAPI on [ScanAPI Demo Project][scanapi-demo].
 
@@ -132,9 +96,5 @@ Commit the change and open a Pull Request with it.
 
 
 [virtualenv]: https://virtualenv.pypa.io/en/latest/
-[pypi]: https://pypi.org
-[pypi-test]: https://test.pypi.org
 [scanapi-demo]: https://github.com/camilamaia/scanapi-demo
 [scanapi-demo-requirements]: https://github.com/camilamaia/scanapi-demo/blob/master/requirements.txt
-[setuptools]: https://packaging.python.org/key_projects/#setuptools
-[twine]: https://packaging.python.org/key_projects/#twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 46.1.3", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Description

Automated PyPI deploy with Github Actions

Reference: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

Closes #36 

We can test it properly in the next release