### PR TITLE
Add tests results to html report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new HTML template [#157](https://github.com/scanapi/scanapi/pull/157)
 - Tests key [#152](https://github.com/scanapi/scanapi/pull/152)
 - `-h` alias for `--help` option [#172](https://github.com/scanapi/scanapi/pull/172)
+- Test results to report [#177](https://github.com/scanapi/scanapi/pull/177)
 
 ### Changed
 - Unified keys validation in a single method [#151](https://github.com/scanapi/scanapi/pull/151)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Console Report [#175](https://github.com/scanapi/scanapi/pull/175)
-<<<<<<< HEAD
 - Markdown Report [#179](https://github.com/scanapi/scanapi/pull/179)
 - `--reporter` option [#179](https://github.com/scanapi/scanapi/pull/179)
-=======
->>>>>>> Update CHANGELOG.md
 
 ## [0.1.0] - 2020-05-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Console Report [#175](https://github.com/scanapi/scanapi/pull/175)
+<<<<<<< HEAD
 - Markdown Report [#179](https://github.com/scanapi/scanapi/pull/179)
 - `--reporter` option [#179](https://github.com/scanapi/scanapi/pull/179)
+=======
+>>>>>>> Update CHANGELOG.md
 
 ## [0.1.0] - 2020-05-14
 ### Added

--- a/scanapi/main.py
+++ b/scanapi/main.py
@@ -3,6 +3,7 @@ import logging
 
 from scanapi.scan import scan
 from scanapi.settings import settings
+from scanapi.session import session
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -21,6 +22,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 )
 def main(spec_path, output_path, config_path, template, log_level):
     """Automated Testing and Documentation for your REST API."""
+    session.start()
     logging.basicConfig(level=log_level, format="%(message)s")
     logger = logging.getLogger(__name__)
 

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-import curlify
 import datetime
 import logging
 
-from jinja2 import Environment, FileSystemLoader, PackageLoader, select_autoescape
-
+from scanapi.session import session
 from scanapi.settings import settings
+from scanapi.template_render import render
 
 logger = logging.getLogger(__name__)
 
@@ -15,17 +14,14 @@ class Reporter:
         self.output_path = output_path or "scanapi-report.html"
         self.template = template
 
-    def write(self, responses):
+    def write(self, results):
         logger.info("Writing documentation")
 
-        if self.template:
-            loader = FileSystemLoader(searchpath="./")
-            template_path = self.template
-        else:
-            loader = PackageLoader("scanapi", "templates")
-            template_path = "html.jinja"
+        template_path = self.template if self.template else "html.jinja"
+        has_external_template = True if self.template else False
+        context = self._build_context(results)
 
-        content = self._render_content(loader, template_path, responses)
+        content = render(template_path, context, has_external_template)
 
         with open(self.output_path, "w", newline="\n") as doc:
             doc.write(content)
@@ -33,10 +29,10 @@ class Reporter:
         logger.info("\nThe documentation was generated successfully.")
         logger.info(f"It is available at {self.output_path}")
 
-    def _render_content(self, loader, template_path, responses):
-        env = Environment(loader=loader)
-        env.filters["curlify"] = curlify.to_curl
-        env.globals["now"] = datetime.datetime.now().replace(microsecond=0)
-        env.globals["project_name"] = settings.get("project-name", "")
-        chosen_template = env.get_template(template_path)
-        return chosen_template.render(responses=responses)
+    def _build_context(self, results):
+        return {
+            "now": datetime.datetime.now().replace(microsecond=0),
+            "project_name": settings.get("project-name", ""),
+            "results": results,
+            "session": session,
+        }

--- a/scanapi/scan.py
+++ b/scanapi/scan.py
@@ -38,16 +38,17 @@ def scan():
             raise MissingMandatoryKeyError({API_KEY}, ROOT_SCOPE)
 
         root_node = EndpointNode(api_spec[API_KEY])
-        responses = root_node.run()
+        results = root_node.run()
+
     except (InvalidKeyError, MissingMandatoryKeyError, KeyError) as e:
         error_message = "Error loading API spec."
         error_message = "{} {}".format(error_message, str(e))
         logger.error(error_message)
         return
 
-    write_report(responses)
+    write_report(results)
 
 
-def write_report(responses):
+def write_report(results):
     reporter = Reporter(settings["output_path"], settings["template"])
-    reporter.write(responses)
+    reporter.write(results)

--- a/scanapi/session.py
+++ b/scanapi/session.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+
+class Session:
+    def __init__(self):
+        self.successes = 0
+        self.failures = 0
+
+    def start(self):
+        self.started_at = datetime.now()
+
+    def increment_successes(self):
+        self.successes += 1
+
+    def increment_failures(self):
+        self.failures += 1
+
+    def elapsed_time(self):
+        return datetime.now() - self.started_at
+
+
+session = Session()

--- a/scanapi/template_render.py
+++ b/scanapi/template_render.py
@@ -1,0 +1,19 @@
+import curlify
+
+from jinja2 import Environment, FileSystemLoader, PackageLoader
+
+
+def render(template_path, context, is_external=False):
+    loader = _loader(is_external)
+    env = Environment(loader=loader)
+    env.filters["curlify"] = curlify.to_curl
+    chosen_template = env.get_template(template_path)
+
+    return chosen_template.render(**context)
+
+
+def _loader(is_external):
+    if is_external:
+        return FileSystemLoader(searchpath="./")
+
+    return PackageLoader("scanapi", "templates")

--- a/scanapi/templates/html.jinja
+++ b/scanapi/templates/html.jinja
@@ -162,11 +162,11 @@
         }
 
         .endpoint__response h3,
-        .endpoint__request h3 {
+        .endpoint__request h3,
+        .endpoint__tests h3 {
+        text-transform: uppercase;
         margin: 20px 0;
-        background: #f9f9f9;
         display: inline-block;
-        padding: 10px 12px;
         border-radius: 10px;
         }
 
@@ -214,6 +214,41 @@
         .endpoint__checkbox:checked ~ .endpoint__content {
         height: auto;
         }
+
+        .endpoint__tests {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .endpoint__testcase {
+            display: flex;
+            flex-direction: row;
+            padding: 10px 0;
+        }
+
+        .endpoint__testcase-status {
+            width: 10%;
+        }
+
+        .endpoint__testcase-label {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .endpoint__testcase-failure{
+            padding: 10px 0;
+        }
+
+        .endpoint__testcase-passed {
+        color: green;
+        }
+
+        .endpoint__testcase-failed {
+        color: red;
+        }
+
+
+
         /* END -- ENDPOINT */
 
         /* STATUS */
@@ -222,22 +257,43 @@
         }
 
         .status--GET {
-        color: #28a745;
+        color: #e0bee4;
         }
 
         .status--POST {
-        color: #ffc107;
+        color: #d291b6;
         }
 
         .status--DELETE {
-        color: #dc3545;
+        color: #fec8d8;
         }
 
         .status--PUT {
-        color: #4a90e2;
+        color: #957dad;
+        }
+
+        .status-PATCH {
+        color: #ffdfd3;
         }
 
         /* END -- STATUS */
+
+        /* TESTS SUMMARY */
+        .tests__summary {
+        background: #f9f9f9;
+        padding: 10px 12px;
+        border-radius: 10px;
+        margin: 0 20px;
+        display: flex;
+        flex-direction: column;
+        }
+
+        .tests__summaryResults{
+        margin-bottom: 21px;
+        display: flex;
+        justify-content: space-between;
+        }
+        /* END TESTS SUMMARY */
     </style>
 
     <div class="header">
@@ -254,7 +310,12 @@
             <p class="title__overview">Generated at: {{now}}</p>
         </header>
 
-        {% for response in responses -%} {% set request = response.request %}
+        {% for result in results -%}
+            {% set response = result["response"] %}
+            {% set tests = result["tests_results"] %}
+            {% set status = "passed" if result["no_failure"] else "failed"%}
+            {% set request = response.request %}
+
             <div class="endpoint">
                 <input type="checkbox" class="endpoint__checkbox" id="chck_{{ loop.index | string }}" />
                 <label class="endpoint__title" for="chck_{{ loop.index | string }}">
@@ -376,9 +437,40 @@
                             </details>
                         {% endif %}
                     </section>
+
+                    <section class="endpoint__tests">
+                        <h3>Tests</h3>
+                        {% for test in tests -%}
+                            {% set status_label = "passed" if test.passed else "failed" %}
+                            <div class="endpoint__testcase">
+                                <div class="endpoint__testcase-status">
+                                    <strong class="endpoint__testcase-{{status_label}}">
+                                        [{{status_label|upper}}]
+                                    </strong>
+                                </div>
+                                <div class="endpoint__testcase-label">
+                                    <span>
+                                        {{test.name}}
+                                    </span>
+                                    {% if test.failure %}
+                                        <span class="endpoint__testcase-failure">{{test.failure}} is false</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    <section>
                 </div>
             </div>
         {% endfor %}
+
+        <div class="tests__summary">
+            <h3>Tests Summary</h3>
+            <div class="tests__summaryResults">
+                <span>PASSED: {{session.successes}}</span>
+                <span>FAILURES: {{session.failures}}</span>
+                <span>Total Time: {{session.elapsed_time()}}</span>
+            </div>
+        </div>
 
         <a class="github" href="https://github.com/scanapi/scanapi"><img class="github__svg" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/github/github-logo.svg" /></a>
 </body>

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -107,11 +107,17 @@ class RequestNode:
             self.spec.get(VARS_KEY, {}), extras={"response": response}, preevaluate=True
         )
 
-        for test in self.tests:
-            test.run()
-
+        tests_results = self._run_tests()
         hide_sensitive_info(response)
-        return response
+
+        return {
+            "response": response,
+            "tests_results": tests_results,
+            "no_failure": all([test_result["passed"] for test_result in tests_results]),
+        }
+
+    def _run_tests(self):
+        return [test.run() for test in self.tests]
 
     def _validate(self):
         validate_keys(

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ test_requirements = [
     "codecov >= 2.0.15",
     "pytest >= 5.2.4",
     "pytest-cov >= 2.8.1",
+    "pytest-freezegun >= 0.4.1",
     "pytest-mock >= 1.11.2",
     "requests-mock >= 1.7.0",
 ]

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -1,51 +1,97 @@
 import pytest
-import jinja2
+
+from freezegun.api import FakeDatetime
 from scanapi.reporter import Reporter
 
-fake_responses = [
-    {"status_code": 200, "request": {"method": "GET", "url": "http://test.com"}}
+fake_results = [
+    {"response": "foo", "tests_results": [], "no_failure": True,},
+    {"response": "bar", "tests_results": [], "no_failure": False,},
 ]
 
 
 class TestReporter:
-    @pytest.fixture
-    def mocked__render_content(self, mocker):
-        return mocker.patch("scanapi.reporter.Reporter._render_content")
+    class TestInit:
+        class TestNoArguments:
+            def test_init_output_path_and_template(self):
+                reporter = Reporter()
 
-    @pytest.fixture
-    def mocked_open(self, mocker):
-        mock = mocker.mock_open()
-        mocker.patch("scanapi.reporter.open", mock)
-        return mock
+                assert reporter.output_path == "scanapi-report.html"
+                assert reporter.template is None
 
-    def test_should_write_to_default_output(
-        self, mocker, mocked__render_content, mocked_open
-    ):
-        mocked__render_content.return_value = "ScanAPI Report"
-        reporter = Reporter()
-        reporter.write(fake_responses)
+        class TestWithTemplate:
+            def test_init_output_path_and_template(self):
+                reporter = Reporter(template="my_template.jinja")
 
-        mocked_open.assert_called_once_with("scanapi-report.html", "w", newline="\n")
-        mocked_open().write.assert_called_once_with("ScanAPI Report")
+                assert reporter.output_path == "scanapi-report.html"
+                assert reporter.template == "my_template.jinja"
 
-    def test_should_write_to_custom_output(
-        self, mocker, mocked__render_content, mocked_open
-    ):
-        mocked__render_content.return_value = "ScanAPI Report"
-        reporter = Reporter("./custom/report-output.html", "html")
-        reporter.write(fake_responses)
+        class TestWithOutputPath:
+            def test_init_output_path_and_template(self):
+                reporter = Reporter(output_path="my-report.html")
 
-        mocked_open.assert_called_once_with(
-            "./custom/report-output.html", "w", newline="\n"
-        )
-        mocked_open().write.assert_called_once_with("ScanAPI Report")
+                assert reporter.output_path == "my-report.html"
+                assert reporter.template is None
 
-    def test_should_handle_custom_templates(
-        self, mocker, mocked__render_content, mocked_open
-    ):
-        mocked__render_content.return_value = "ScanAPI Report"
-        reporter = Reporter(template="my-template.html")
-        reporter.write(fake_responses)
+    @pytest.mark.freeze_time("2020-05-12 11:32:34")
+    class TestWrite:
+        @pytest.fixture
+        def mocked__render(self, mocker):
+            return mocker.patch("scanapi.reporter.render")
 
-        mocked_open.assert_called_once_with("scanapi-report.html", "w", newline="\n")
-        mocked_open().write.assert_called_once_with("ScanAPI Report")
+        @pytest.fixture
+        def mocked__session(self, mocker):
+            return mocker.patch("scanapi.reporter.session")
+
+        @pytest.fixture
+        def context(self, mocked__session):
+            return {
+                "now": FakeDatetime(2020, 5, 12, 11, 32, 34),
+                "project_name": "",
+                "results": fake_results,
+                "session": mocked__session,
+            }
+
+        @pytest.fixture
+        def mocked__open(self, mocker):
+            mock = mocker.mock_open()
+            mocker.patch("scanapi.reporter.open", mock)
+            return mock
+
+        def test_should_write_to_default_output(
+            self, mocker, mocked__render, mocked__open, mocked__session, context,
+        ):
+            mocked__render.return_value = "ScanAPI Report"
+            reporter = Reporter()
+            reporter.write(fake_results)
+
+            mocked__render.assert_called_once_with("html.jinja", context, False)
+            mocked__open.assert_called_once_with(
+                "scanapi-report.html", "w", newline="\n"
+            )
+            mocked__open().write.assert_called_once_with("ScanAPI Report")
+
+        def test_should_write_to_custom_output(
+            self, mocker, mocked__render, mocked__open, mocked__session, context,
+        ):
+            mocked__render.return_value = "ScanAPI Report"
+            reporter = Reporter("./custom/report-output.html", "html")
+            reporter.write(fake_results)
+
+            mocked__render.assert_called_once_with("html", context, True)
+            mocked__open.assert_called_once_with(
+                "./custom/report-output.html", "w", newline="\n"
+            )
+            mocked__open().write.assert_called_once_with("ScanAPI Report")
+
+        def test_should_handle_custom_templates(
+            self, mocker, mocked__render, mocked__open, mocked__session, context,
+        ):
+            mocked__render.return_value = "ScanAPI Report"
+            reporter = Reporter(template="my-template.html")
+            reporter.write(fake_results)
+
+            mocked__render.assert_called_once_with("my-template.html", context, True)
+            mocked__open.assert_called_once_with(
+                "scanapi-report.html", "w", newline="\n"
+            )
+            mocked__open().write.assert_called_once_with("ScanAPI Report")

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,52 @@
+import pytest
+
+from random import randrange
+
+from scanapi.session import Session
+
+
+class TestSession:
+    class TestInit:
+        def test_init_successes_and_failures(self):
+            session = Session()
+
+            assert session.successes == 0
+            assert session.failures == 0
+
+    class TestStart:
+        @pytest.mark.freeze_time("2020-06-15 18:54:57")
+        def test_init_started_at(self):
+            session = Session()
+            session.start()
+
+            assert str(session.started_at) == "2020-06-15 18:54:57"
+
+    class TestIncrementSuccesses:
+        def test_increment(self):
+            session = Session()
+            times = randrange(1, 100)
+
+            for _ in range(times):
+                session.increment_successes()
+
+            assert session.successes == times
+
+    class TestIncrementFailures:
+        def test_increment(self):
+            session = Session()
+            times = randrange(1, 100)
+
+            for _ in range(times):
+                session.increment_failures()
+
+            assert session.failures == times
+
+    class TestElapsedTime:
+        @pytest.mark.freeze_time("2020-06-15 18:54:57")
+        def test_return_time(self, freezer):
+            session = Session()
+            session.start()
+
+            freezer.move_to("2020-06-15 18:56:38")
+
+            assert str(session.elapsed_time()) == "0:01:41"

--- a/tests/unit/test_template_render.py
+++ b/tests/unit/test_template_render.py
@@ -1,0 +1,32 @@
+import pytest
+import jinja2
+
+from scanapi.template_render import render, _loader
+
+
+class TestTemplateRender:
+    class TestRender:
+        @pytest.fixture
+        def mocked__get_template(self, mocker):
+            return mocker.patch("scanapi.template_render.Environment.get_template")
+
+        def test_should_call_jinja_render(self, mocked__get_template):
+            context = {"my_context": "foo"}
+            render("my_template.jinja", context)
+
+            mocked__get_template.assert_called_once_with("my_template.jinja")
+            mocked__get_template().render.assert_called_once_with(**context)
+
+    class TestLoader:
+        class TestWhenIsExternal:
+            def test_return_file_system_loader(self):
+                loader = _loader(True)
+
+                assert loader.__class__.__name__ == "FileSystemLoader"
+                assert loader.searchpath == ["./"]
+
+        class TestWhenIsNotExternal:
+            def test_return_package_loader(self):
+                loader = _loader(False)
+                assert loader.__class__.__name__ == "PackageLoader"
+                assert loader.package_path == "templates"


### PR DESCRIPTION
- Show a tests summary in the HTML report
- Show each test result in the html report
- Small refactor on Reporter

Current this is how it is rendered: https://github.com/scanapi/scanapi/blob/adr2/testing_reports/current.html

![report](https://user-images.githubusercontent.com/2728804/85136382-edafcc00-b215-11ea-8b18-0e54a1656c1a.png)
![report2](https://user-images.githubusercontent.com/2728804/85136389-ef798f80-b215-11ea-8913-268c62fe84a6.png)


But we are still discussing better how we are going to present it #161 . We can improve it later in the next PRs.

Closes #169 
Closes #167 