### PR TITLE
Fix sensitive information and duplicated row on report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Entry point to `scanapi:main` [#172](https://github.com/scanapi/scanapi/pull/172)
 - `--spec-path` option to argument [#172](https://github.com/scanapi/scanapi/pull/172)
 
+### Fixed
+- Duplicated status code row from report [#183](https://github.com/scanapi/scanapi/pull/183)
+- Sensitive information render on report [#183](https://github.com/scanapi/scanapi/pull/183)
+
 ### Removed
 - Console Report [#175](https://github.com/scanapi/scanapi/pull/175)
 - Markdown Report [#179](https://github.com/scanapi/scanapi/pull/179)

--- a/scanapi/templates/html.jinja
+++ b/scanapi/templates/html.jinja
@@ -311,17 +311,6 @@
                     <section class="endpoint__response">
                         <h3>Response</h3>
                         <table>
-                            <thead>
-                                <tr>
-                                    <td>
-                                        status code
-                                    </td>
-                                    <td>
-                                        {{ response.status_code }}
-                                    </td>
-                                </tr>
-                            </thead>
-
                             <tbody>
                                 <tr>
                                     <td>

--- a/scanapi/utils.py
+++ b/scanapi/utils.py
@@ -56,4 +56,4 @@ def _override_info(http_msg, http_attr, secret_field):
         secret_field in getattr(http_msg, http_attr)
         and http_attr in ALLOWED_ATTRS_TO_HIDE
     ):
-        getattr(http_msg, http_attr)[secret_field] = "<sensitive_information>"
+        getattr(http_msg, http_attr)[secret_field] = "SENSITIVE_INFORMATION"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -163,7 +163,7 @@ class TestOverrideInfo:
 
         _override_info(response, http_attr, secret_field)
 
-        assert response.headers["abc"] == "<sensitive_information>"
+        assert response.headers["abc"] == "SENSITIVE_INFORMATION"
 
     def test_when_http_attr_is_not_allowed(self, response, mocker):
         mocker.patch("scanapi.utils.ALLOWED_ATTRS_TO_HIDE", ["body"])


### PR DESCRIPTION
- Remove duplicated status code row from report
- Fix sensitive information render on report. It was not showing in the report because it was being interpreted as a html tag

Detailed explanation of each problem in their respective issues
👇 

Closes #181 
Closes #182 