### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0] - 2020-06-25
 ### Added
 - Add new HTML template [#157](https://github.com/scanapi/scanapi/pull/157)
 - Tests key [#152](https://github.com/scanapi/scanapi/pull/152)
@@ -121,7 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/camilamaia/scanapi/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/camilamaia/scanapi/compare/v0.0.19...v0.1.0
 [0.0.19]: https://github.com/camilamaia/scanapi/compare/v0.0.18...v0.0.19
 [0.0.18]: https://github.com/camilamaia/scanapi/compare/v0.0.17...v0.0.18

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="scanapi",
-    version="0.1.0",
+    version="1.0.0",
     author="Camila Maia",
     author_email="cmaiacd@gmail.com",
     description="Automated Testing and Documentation for your REST API",


### PR DESCRIPTION
### Added
- Add new HTML template [#157](https://github.com/scanapi/scanapi/pull/157)
- Tests key [#152](https://github.com/scanapi/scanapi/pull/152)
- `-h` alias for `--help` option [#172](https://github.com/scanapi/scanapi/pull/172)
- Test results to report [#177](https://github.com/scanapi/scanapi/pull/177)
- Add test errors to the report [#187](https://github.com/scanapi/scanapi/pull/187)
- Hides sensitive info in URL [#185](https://github.com/scanapi/scanapi/pull/185)
- CLI options explanation [#189](https://github.com/scanapi/scanapi/pull/189)

### Changed
- Unified keys validation in a single method [#151](https://github.com/scanapi/scanapi/pull/151)
- Default template to html [#173](https://github.com/scanapi/scanapi/pull/173)
- Project name color on html reporter to match ScanAPI brand [#172](https://github.com/scanapi/scanapi/pull/172)
- Hero banner on README [#180](https://github.com/scanapi/scanapi/pull/180)
- Entry point to `scanapi:main` [#172](https://github.com/scanapi/scanapi/pull/172)
- `--spec-path` option to argument [#172](https://github.com/scanapi/scanapi/pull/172)
- Improve test results on report [#186](https://github.com/scanapi/scanapi/pull/186)
- Improve Error Message for Invalid Python code error [#187](https://github.com/scanapi/scanapi/pull/187)
- Handle properly exit errors [#187](https://github.com/scanapi/scanapi/pull/187)
- Update README.md [#191](https://github.com/scanapi/scanapi/pull/191)

### Fixed
- Duplicated status code row from report [#183](https://github.com/scanapi/scanapi/pull/183)
- Sensitive information render on report [#183](https://github.com/scanapi/scanapi/pull/183)

### Removed
- Console Report [#175](https://github.com/scanapi/scanapi/pull/175)
- Markdown Report [#179](https://github.com/scanapi/scanapi/pull/179)
- `--reporter` option [#179](https://github.com/scanapi/scanapi/pull/179)