### PR TITLE
Vertically centered status icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Status icons on report were not vertically centered [#195](https://github.com/scanapi/scanapi/pull/195)
 
 ## [1.0.1] - 2020-06-25
 ### Fixed

--- a/scanapi/templates/html.jinja
+++ b/scanapi/templates/html.jinja
@@ -205,6 +205,9 @@
         color: white;
         font-size: 14px;
         line-height: 20px;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
         }
 
         .endpoint__status--P {


### PR DESCRIPTION
### Fixed

- Status icons are not vertically centred in the Report [#190]