### PR TITLE
Remove the `api` top-level key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Renamed `api.(yaml|json)` to `scanapi.yaml` [#222](https://github.com/scanapi/scanapi/issues/20://github.com/scanapi/scanapi/pull/222)
+- Remove top-level `api` key in `scanapi.yaml`. [#231](https://github.com/scanapi/scanapi/pull/231)
 
 ### Fixed
 - Updated language use in README.md and CONTRIBUTING.md plus fix broken links [#220](https://github.com/scanapi/scanapi/pull/220)

--- a/README.md
+++ b/README.md
@@ -58,17 +58,16 @@ You will need to write the API's specification and save it as a **YAML** or **JS
 For example:
 
 ```yaml
-api:
-  endpoints:
-    - name: scanapi-demo # The API's name of your API
-      path: http://demo.scanapi.dev/api/ # The API's base url
-      requests:
-        - name: list_all_devs # The name of the first request
-          path: devs/ # The path of the first request
-          method: get # The HTTP method of the first request
-          tests:
-            - name: status_code_is_200 # The name of the first test for this request
-              assert: ${{ response.status_code == 200 }} # The assertion
+endpoints:
+  - name: scanapi-demo # The API's name of your API
+    path: http://demo.scanapi.dev/api/ # The API's base url
+    requests:
+      - name: list_all_devs # The name of the first request
+        path: devs/ # The path of the first request
+        method: get # The HTTP method of the first request
+        tests:
+          - name: status_code_is_200 # The name of the first test for this request
+            assert: ${{ response.status_code == 200 }} # The assertion
 ```
 
 And run the scanapi command
@@ -156,14 +155,13 @@ $ export BASE_URL="http://demo.scanapi.dev/api/"
 ```
 
 ```yaml
-api:
-  endpoints:
-    - name: scanapi-demo
-      path: ${BASE_URL}
-      requests:
-        - name: health
-          method: get
-          path: /health/
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests:
+      - name: health
+        method: get
+        path: /health/
 ```
 
 ScanAPI would call the following `http://demo.scanapi.dev/api/health/` then.
@@ -275,11 +273,10 @@ For example, these two files
 
 ```yaml
 # scanapi.yaml
-api:
-  endpoints:
-    - name: scanapi-demo
-      path: ${BASE_URL}
-      requests: !include include.yaml
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests: !include include.yaml
 ```
 
 ```yaml
@@ -291,13 +288,12 @@ api:
 would generate:
 
 ```yaml
-api:
-  endpoints:
-    - name: scanapi-demo
-      path: ${BASE_URL}
-      requests:
-        - name: health
-          path: /health/
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests:
+      - name: health
+        path: /health/
 ```
 
 ### Configuration File

--- a/scanapi/scan.py
+++ b/scanapi/scan.py
@@ -7,14 +7,13 @@ from scanapi.errors import (
     EmptyConfigFileError,
     InvalidKeyError,
     InvalidPythonCodeError,
-    MissingMandatoryKeyError,
 )
 from scanapi.exit_code import ExitCode
 from scanapi.reporter import Reporter
 from scanapi.session import session
 from scanapi.settings import settings
 from scanapi.tree import EndpointNode
-from scanapi.tree.tree_keys import API_KEY, ROOT_SCOPE
+from scanapi.tree.tree_keys import ROOT_SCOPE
 
 logger = logging.getLogger(__name__)
 
@@ -37,18 +36,10 @@ def scan():
         raise SystemExit(ExitCode.USAGE_ERROR)
 
     try:
-        if API_KEY not in api_spec:
-            raise MissingMandatoryKeyError({API_KEY}, ROOT_SCOPE)
-
-        root_node = EndpointNode(api_spec[API_KEY])
+        root_node = EndpointNode(api_spec)
         results = root_node.run()
 
-    except (
-        InvalidKeyError,
-        MissingMandatoryKeyError,
-        KeyError,
-        InvalidPythonCodeError,
-    ) as e:
+    except (InvalidKeyError, KeyError, InvalidPythonCodeError,) as e:
         error_message = "Error loading API spec."
         error_message = "{} {}".format(error_message, str(e))
         logger.error(error_message)

--- a/scanapi/tree/tree_keys.py
+++ b/scanapi/tree/tree_keys.py
@@ -1,4 +1,3 @@
-API_KEY = "api"
 ASSERT_KEY = "assert"
 BODY_KEY = "body"
 ENDPOINTS_KEY = "endpoints"

--- a/tests/data/api_invalid_path_include.yaml
+++ b/tests/data/api_invalid_path_include.yaml
@@ -1,5 +1,4 @@
-api:
-  endpoints:
-    - name: scanapi-demo
-      path: ${BASE_URL}
-      requests: !include invalid_path/include.yaml
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests: !include invalid_path/include.yaml

--- a/tests/data/api_wrong_format_include.yaml
+++ b/tests/data/api_wrong_format_include.yaml
@@ -1,5 +1,4 @@
-api:
-  endpoints:
-    - name: scanapi-demo
-      path: ${BASE_URL}
-      requests: !include include.txt
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests: !include include.txt

--- a/tests/data/jsonfile.json
+++ b/tests/data/jsonfile.json
@@ -1,11 +1,9 @@
 {
-    "api": {
-        "endpoints": [
-            {
-                "name": "scanapi-demo",
-                "path": "${BASE_URL}",
-                "requests": !include include.json
-            }
-        ]
-    }
+    "endpoints": [
+        {
+            "name": "scanapi-demo",
+            "path": "${BASE_URL}",
+            "requests": !include include.json
+        }
+    ]
 }

--- a/tests/data/not_supported_format.txt
+++ b/tests/data/not_supported_format.txt
@@ -1,5 +1,4 @@
-api:
-  endpoints:
-    - name: scanapi-demo
-      path: ${BASE_URL}
-      requests: !include include.yaml
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests: !include include.yaml

--- a/tests/data/scanapi.yaml
+++ b/tests/data/scanapi.yaml
@@ -1,5 +1,4 @@
-api:
-  endpoints:
-    - name: scanapi-demo
-      path: ${BASE_URL}
-      requests: !include include.yaml
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests: !include include.yaml

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -9,7 +9,19 @@ class TestLoadConfigFile:
     def test_should_load(self):
         data = load_config_file("tests/data/scanapi.yaml")
         assert data == {
-            "api": {
+            "endpoints": [
+                {
+                    "name": "scanapi-demo",
+                    "path": "${BASE_URL}",
+                    "requests": [{"name": "health", "path": "/health/"}],
+                }
+            ]
+        }
+
+    class TestLoadJson:
+        def test_should_load(self):
+            data = load_config_file("tests/data/jsonfile.json")
+            assert data == {
                 "endpoints": [
                     {
                         "name": "scanapi-demo",
@@ -17,22 +29,6 @@ class TestLoadConfigFile:
                         "requests": [{"name": "health", "path": "/health/"}],
                     }
                 ]
-            }
-        }
-
-    class TestLoadJson:
-        def test_should_load(self):
-            data = load_config_file("tests/data/jsonfile.json")
-            assert data == {
-                "api": {
-                    "endpoints": [
-                        {
-                            "name": "scanapi-demo",
-                            "path": "${BASE_URL}",
-                            "requests": [{"name": "health", "path": "/health/"}],
-                        }
-                    ]
-                }
             }
 
     class TestWhenFileDoesNotExist:

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -8,7 +8,6 @@ import yaml
 from scanapi.errors import (
     EmptyConfigFileError,
     InvalidKeyError,
-    MissingMandatoryKeyError,
 )
 from scanapi.scan import scan, write_report
 
@@ -31,10 +30,6 @@ def yaml_error(*args, **kwargs):
 
 def invalid_key(*args, **kwargs):
     raise InvalidKeyError("foo", "endpoint", ["bar", "other"])
-
-
-def missing_mandatory_key(*args, **kwargs):
-    raise MissingMandatoryKeyError(["foo", "bar"], "endpoint")
 
 
 @pytest.fixture
@@ -93,7 +88,7 @@ class TestScan:
     class TestWhenAPISpecHasAnInvalidKey:
         def test_should_log_error(self, mocker, caplog):
             mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
-            mock_load_config_file.return_value = {"api": "blah"}
+            mock_load_config_file.return_value = {"blah": "blah"}
             mocker.patch("scanapi.scan.EndpointNode.__init__", side_effect=invalid_key)
             with caplog.at_level(logging.INFO):
                 with pytest.raises(SystemExit) as excinfo:
@@ -107,46 +102,10 @@ class TestScan:
                 "are: ['bar', 'other']" in caplog.text
             )
 
-    class TestWhenAPISpecIsMissingMandatoryKey:
-        def test_should_log_error(self, mocker, caplog):
-            mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
-            mock_load_config_file.return_value = {"api": "blah"}
-
-            mocker.patch(
-                "scanapi.scan.EndpointNode.__init__", side_effect=missing_mandatory_key,
-            )
-            with caplog.at_level(logging.INFO):
-                with pytest.raises(SystemExit) as excinfo:
-                    scan()
-
-                assert excinfo.type == SystemExit
-                assert excinfo.value.code == 4
-
-            assert (
-                "Error loading API spec. Missing 'bar', 'foo' key(s) at 'endpoint' scope"
-                in caplog.text
-            )
-
-    class TestWhenAPISpecIsMissingAPIKey:
-        def test_should_log_error(self, mocker, caplog):
-            mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
-
-            with caplog.at_level(logging.INFO):
-                with pytest.raises(SystemExit) as excinfo:
-                    scan()
-
-                assert excinfo.type == SystemExit
-                assert excinfo.value.code == 4
-
-            assert (
-                "Error loading API spec. Missing 'api' key(s) at 'root' scope"
-                in caplog.text
-            )
-
     class TestWhenAPISpecIsOk:
         def test_should_call_reporter(self, mocker, response):
             mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
-            mock_load_config_file.return_value = {"api": {"endpoints": []}}
+            mock_load_config_file.return_value = {"endpoints": []}
             mock_endpoint_init = mocker.patch("scanapi.scan.EndpointNode.__init__")
             mock_endpoint_init.return_value = None
             mock_endpoint_run = mocker.patch("scanapi.scan.EndpointNode.run")


### PR DESCRIPTION
In #209 it was suggested to remove the top-level `api` key, this PR removes that but it does not deal with the possibility of it being there. Since for the previous PRs we let things ride regarding backwards compatibility I wonder if it's still necessary for this PR.

Closes #209 