### PR TITLE
Updated naming convetions to use underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Renamed `api.(yaml|json)` to `scanapi.yaml` [#222](https://github.com/scanapi/scanapi/issues/20://github.com/scanapi/scanapi/pull/222)
 - Remove top-level `api` key in `scanapi.yaml`. [#231](https://github.com/scanapi/scanapi/pull/231)
+- Renamed `project-name`, `hide-request` and `hide-response` to use underscore. [#228](https://github.com/scanapi/scanapi/issues/228)
 
 ### Fixed
 - Updated language use in README.md and CONTRIBUTING.md plus fix broken links [#220](https://github.com/scanapi/scanapi/pull/220)

--- a/scanapi/hide_utils.py
+++ b/scanapi/hide_utils.py
@@ -11,8 +11,8 @@ SENSITIVE_INFO_SUBSTITUTION_FLAG = "SENSITIVE_INFORMATION"
 def hide_sensitive_info(response):
     report_settings = settings.get("report", {})
     request = response.request
-    request_settings = report_settings.get("hide-request", {})
-    response_settings = report_settings.get("hide-response", {})
+    request_settings = report_settings.get("hide_request", {})
+    response_settings = report_settings.get("hide_response", {})
 
     _hide(request, request_settings)
     _hide(response, response_settings)

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -33,7 +33,7 @@ class Reporter:
     def _build_context(results):
         return {
             "now": datetime.datetime.now().replace(microsecond=0),
-            "project_name": settings.get("project-name", ""),
+            "project_name": settings.get("project_name", ""),
             "results": results,
             "session": session,
         }

--- a/tests/unit/test_hide_utils.py
+++ b/tests/unit/test_hide_utils.py
@@ -18,10 +18,10 @@ class TestHideSensitiveInfo:
     test_data = [
         ({}, {}, {}),
         ({"report": {"abc": "def"}}, {}, {}),
-        ({"report": {"hide-request": {"url": ["abc"]}}}, {"url": ["abc"]}, {}),
-        ({"report": {"hide-request": {"headers": ["abc"]}}}, {"headers": ["abc"]}, {},),
+        ({"report": {"hide_request": {"url": ["abc"]}}}, {"url": ["abc"]}, {}),
+        ({"report": {"hide_request": {"headers": ["abc"]}}}, {"headers": ["abc"]}, {},),
         (
-            {"report": {"hide-response": {"headers": ["abc"]}}},
+            {"report": {"hide_response": {"headers": ["abc"]}}},
             {},
             {"headers": ["abc"]},
         ),


### PR DESCRIPTION
* reporter.py: `project-name` -> `project_name`
* hide_utils.py: `hide-request` -> `hide_request`
* hide_utils.py: `hide-response` -> `hide_response`

closes #228 