### PR TITLE
Fix hide body sensitive info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated language use in README.md and CONTRIBUTING.md plus fix broken links [#220](https://github.com/scanapi/scanapi/pull/220)
 - Removed unused sys import in scan.py and cleaned for PEP8 and spelling errors [#217](https://github.com/scanapi/scanapi/pull/217)
+- Hide body sensitive information [#238](https://github.com/scanapi/scanapi/pull/238)
 
 ### Removed
 - APIKeyMissingError [#218](https://github.com/scanapi/scanapi/pull/218)

--- a/scanapi/hide_utils.py
+++ b/scanapi/hide_utils.py
@@ -1,10 +1,11 @@
+import json
+
 from scanapi.settings import settings
 
 HEADERS = "headers"
 BODY = "body"
 URL = "url"
 
-ALLOWED_ATTRS_TO_HIDE = (HEADERS, BODY, URL)
 SENSITIVE_INFO_SUBSTITUTION_FLAG = "SENSITIVE_INFORMATION"
 
 
@@ -31,16 +32,28 @@ def _hide(http_msg, hide_settings):
 
 def _override_info(http_msg, http_attr, secret_field):
     """ Private method that substitutes sensitive data with string 'SENSITIVE_INFORMATION' """
-    if (
-        secret_field in getattr(http_msg, http_attr)
-        and http_attr in ALLOWED_ATTRS_TO_HIDE
-    ):
-        if http_attr == URL:
-            new_url = getattr(http_msg, http_attr).replace(
-                secret_field, SENSITIVE_INFO_SUBSTITUTION_FLAG
-            )
-            setattr(http_msg, http_attr, new_url)
-        else:
-            getattr(http_msg, http_attr)[
-                secret_field
-            ] = SENSITIVE_INFO_SUBSTITUTION_FLAG
+
+    if http_attr == URL:
+        _override_url(http_msg, secret_field)
+    elif http_attr == HEADERS:
+        _override_headers(http_msg, secret_field)
+    elif http_attr == BODY:
+        _override_body(http_msg, secret_field)
+
+
+def _override_url(http_msg, secret_field):
+    if secret_field in http_msg.url:
+        new_url = http_msg.url.replace(secret_field, SENSITIVE_INFO_SUBSTITUTION_FLAG)
+        http_msg.url = new_url
+
+
+def _override_headers(http_msg, secret_field):
+    if secret_field in http_msg.headers:
+        http_msg.headers[secret_field] = SENSITIVE_INFO_SUBSTITUTION_FLAG
+
+
+def _override_body(http_msg, secret_field):
+    body = json.loads(http_msg.body.decode("UTF-8"))
+    if secret_field in body:
+        body[secret_field] = SENSITIVE_INFO_SUBSTITUTION_FLAG
+        http_msg.body = json.dumps(body).encode("utf-8")

--- a/tests/unit/test_hide_utils.py
+++ b/tests/unit/test_hide_utils.py
@@ -71,16 +71,7 @@ class TestHide:
 
 
 class TestOverrideInfo:
-    def test_overrides(self, response):
-        response.headers = {"abc": "123"}
-        http_attr = "headers"
-        secret_field = "abc"
-
-        _override_info(response, http_attr, secret_field)
-
-        assert response.headers["abc"] == "SENSITIVE_INFORMATION"
-
-    def test_overrides_sensitive_info_url(self, response):
+    def test_overrides_url(self, response):
         secret_key = "129e8cb2-d19c-51ad-9921-cea329bed7fa"
         response.url = (
             f"http://test.com/users/129e8cb2-d19c-51ad-9921-cea329bed7fa/details"
@@ -92,18 +83,28 @@ class TestOverrideInfo:
 
         assert response.url == "http://test.com/users/SENSITIVE_INFORMATION/details"
 
-    def test_when_http_attr_is_not_allowed(self, response, mocker):
-        mocker.patch("scanapi.hide_utils.ALLOWED_ATTRS_TO_HIDE", ["body"])
+    def test_overrides_headers(self, response):
         response.headers = {"abc": "123"}
         http_attr = "headers"
         secret_field = "abc"
 
         _override_info(response, http_attr, secret_field)
 
-        assert response.headers["abc"] == "123"
+        assert response.headers["abc"] == "SENSITIVE_INFORMATION"
+
+    def test_overrides_body(self, response):
+        response.body = b'{"id": "abc21", "name": "Tarik", "yearsOfExperience": 2}'
+        http_attr = "body"
+        secret_field = "id"
+
+        _override_info(response, http_attr, secret_field)
+
+        assert (
+            response.body
+            == b'{"id": "SENSITIVE_INFORMATION", "name": "Tarik", "yearsOfExperience": 2}'
+        )
 
     def test_when_http_attr_does_not_have_the_field(self, response, mocker):
-        mocker.patch("scanapi.hide_utils.ALLOWED_ATTRS_TO_HIDE", ["body"])
         response.headers = {"abc": "123"}
         http_attr = "headers"
         secret_field = "def"


### PR DESCRIPTION
## Fix hide body sensitive info

When trying to hide body sensitive information:

```yaml
report:
  hide_request:
    headers:
      - Authorization
    body:
      - get_token
```
the user is facing this error:

`a bytes-like object is required, not 'str'`

This PR fixes it. Closes #235 