### PR TITLE
Rename html.jinja to report.html

### DIFF
--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -20,7 +20,7 @@ class Reporter:
         """
         logger.info("Writing documentation")
 
-        template_path = self.template if self.template else "html.jinja"
+        template_path = self.template if self.template else "report.html"
         has_external_template = True if self.template else False
         context = self._build_context(results)
 

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -346,7 +346,7 @@
         <!-- summary_box -->
 
         {% for result in results -%}
-        {% set response = result["response"] %}
+    {% set response = result["response"] %}
         {% set tests = result["tests_results"] %}
         {% set endpoint_status_label = "P" if result["no_failure"] else "F" %}
         {% set request = response.request %}

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -64,7 +64,7 @@ class TestReporter:
             reporter = Reporter()
             reporter.write(fake_results)
 
-            mocked__render.assert_called_once_with("html.jinja", context, False)
+            mocked__render.assert_called_once_with("report.html", context, False)
             mocked__open.assert_called_once_with(
                 "scanapi-report.html", "w", newline="\n"
             )


### PR DESCRIPTION
Rename html.jinja to report.html.

We only have one report type now. Does not make sense to call it `html.jinja`.