### PR TITLE
Fix publish to Test PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.1
+        uses: JRubics/poetry-publish@v1.2
         with:
           python_version: "3.6"
           poetry_version: ">=0.12"

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build and publish to test pypi
-        uses: JRubics/poetry-publish@v1.1
+        uses: JRubics/poetry-publish@v1.2
         with:
           python_version: "3.6"
           poetry_version: ">=0.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "1.0.5"
+version = "1.0.5-rc.1"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Update poetry-publish action, that fixes authentication problem when using repository params.

https://github.com/JRubics/poetry-publish/releases/tag/v1.2

Closes #249 