### PR TITLE
feat: Add local/global configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `project-name`, `hide-request` and `hide-response` to use underscore. [#228](https://github.com/scanapi/scanapi/issues/228)
 - Changed command `scanapi spec-file.yaml` to `scanapi run spec-file.yaml`. [#247](https://github.com/scanapi/scanapi/pull/247)
 - Moved Documentation from README.md to the website [#250](https://github.com/scanapi/scanapi/pull/250)
+- Global configuration.
 
 ### Fixed
 - Updated language use in README.md and CONTRIBUTING.md plus fix broken links [#220](https://github.com/scanapi/scanapi/pull/220)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,160 +8,162 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - JSON response is now properly rendered, instead of plain text. [#213](https://github.com/scanapi/scanapi/pull/213)
-- The report page now has a favicon [#223](https://github.com/scanapi/scanapi/pull/223)
-- Bandit security audit tool [#219](https://github.com/scanapi/scanapi/pull/219)
-- Add Sphinx auto-documentation [#230](https://github.com/scanapi/scanapi/pull/230)
-- Add workflow to package/publish to Test PyPi [#239](https://github.com/scanapi/scanapi/pull/239)
+- The report page now has a favicon. [#223](https://github.com/scanapi/scanapi/pull/223)
+- Bandit security audit tool. [#219](https://github.com/scanapi/scanapi/pull/219)
+- Add Sphinx auto-documentation. [#230](https://github.com/scanapi/scanapi/pull/230)
+- Add workflow to package/publish to Test PyPi. [#239](https://github.com/scanapi/scanapi/pull/239)
 
 ### Changed
-- Renamed `api.(yaml|json)` to `scanapi.yaml` [#222](https://github.com/scanapi/scanapi/issues/20://github.com/scanapi/scanapi/pull/222)
+- Renamed `api.(yaml|json)` to `scanapi.yaml`. [#222](https://github.com/scanapi/scanapi/issues/20://github.com/scanapi/scanapi/pull/222)
 - Remove top-level `api` key in `scanapi.yaml`. [#231](https://github.com/scanapi/scanapi/pull/231)
 - Renamed `project-name`, `hide-request` and `hide-response` to use underscore. [#228](https://github.com/scanapi/scanapi/issues/228)
 - Changed command `scanapi spec-file.yaml` to `scanapi run spec-file.yaml`. [#247](https://github.com/scanapi/scanapi/pull/247)
-- Moved Documentation from README.md to the website [#250](https://github.com/scanapi/scanapi/pull/250)
-- Global configuration.
+- Moved Documentation from README.md to the website. [#250](https://github.com/scanapi/scanapi/pull/250)
+- Local and global configuration. [#254](https://github.com/scanapi/scanapi/pull/254)
 
 ### Fixed
-- Updated language use in README.md and CONTRIBUTING.md plus fix broken links [#220](https://github.com/scanapi/scanapi/pull/220)
-- Removed unused sys import in scan.py and cleaned for PEP8 and spelling errors [#217](https://github.com/scanapi/scanapi/pull/217)
-- Hide body sensitive information [#238](https://github.com/scanapi/scanapi/pull/238)
+- Updated language use in README.md and CONTRIBUTING.md plus fix broken links. [#220](https://github.com/scanapi/scanapi/pull/220)
+- Removed unused sys import in scan.py and cleaned for PEP8 and spelling errors. [#217](https://github.com/scanapi/scanapi/pull/217)
+- Hide body sensitive information. [#238](https://github.com/scanapi/scanapi/pull/238)
 
 ### Removed
-- APIKeyMissingError [#218](https://github.com/scanapi/scanapi/pull/218)
+- APIKeyMissingError. [#218](https://github.com/scanapi/scanapi/pull/218)
 
 ## [1.0.5] - 2020-07-18
 ### Fixed
-- Status icons on report were not vertically centered [#195](https://github.com/scanapi/scanapi/pull/195)
+- Status icons on report were not vertically centered. [#195](https://github.com/scanapi/scanapi/pull/195)
 
 ## [1.0.4] - 2020-06-25
 
 ## [1.0.3] - 2020-06-25
 ### Added
-- MANIFEST.in
+- MANIFEST.in.
 
 ## [1.0.2] - 2020-06-25
 ### Fixed
-- Fix for TemplateNotFound Error [#197](https://github.com/scanapi/scanapi/pull/197)
+- Fix for TemplateNotFound Error. [#197](https://github.com/scanapi/scanapi/pull/197)
 
 ## [1.0.1] - 2020-06-25
 ### Fixed
-- Report example images not loading on PyPI [#193](https://github.com/scanapi/scanapi/pull/193)
+- Report example images not loading on PyPI. [#193](https://github.com/scanapi/scanapi/pull/193)
 
 ## [1.0.0] - 2020-06-25
 ### Added
-- Add new HTML template [#157](https://github.com/scanapi/scanapi/pull/157)
-- Tests key [#152](https://github.com/scanapi/scanapi/pull/152)
-- `-h` alias for `--help` option [#172](https://github.com/scanapi/scanapi/pull/172)
-- Test results to report [#177](https://github.com/scanapi/scanapi/pull/177)
-- Add test errors to the report [#187](https://github.com/scanapi/scanapi/pull/187)
-- Hides sensitive info in URL [#185](https://github.com/scanapi/scanapi/pull/185)
-- CLI options explanation [#189](https://github.com/scanapi/scanapi/pull/189)
+- Add new HTML template. [#157](https://github.com/scanapi/scanapi/pull/157)
+- Tests key. [#152](https://github.com/scanapi/scanapi/pull/152)
+- `-h` alias for `--help` option. [#172](https://github.com/scanapi/scanapi/pull/172)
+- Test results to report. [#177](https://github.com/scanapi/scanapi/pull/177)
+- Add test errors to the report. [#187](https://github.com/scanapi/scanapi/pull/187)
+- Hides sensitive info in URL. [#185](https://github.com/scanapi/scanapi/pull/185)
+- CLI options explanation. [#189](https://github.com/scanapi/scanapi/pull/189)
 
 ### Changed
-- Unified keys validation in a single method [#151](https://github.com/scanapi/scanapi/pull/151)
-- Default template to html [#173](https://github.com/scanapi/scanapi/pull/173)
+- Unified keys validation in a single method. [#151](https://github.com/scanapi/scanapi/pull/151)
+- Default template to html. [#173](https://github.com/scanapi/scanapi/pull/173)
 - Project name color on html reporter to match ScanAPI brand [#172](https://github.com/scanapi/scanapi/pull/172)
-- Hero banner on README [#180](https://github.com/scanapi/scanapi/pull/180)
-- Entry point to `scanapi:main` [#172](https://github.com/scanapi/scanapi/pull/172)
-- `--spec-path` option to argument [#172](https://github.com/scanapi/scanapi/pull/172)
-- Improve test results on report [#186](https://github.com/scanapi/scanapi/pull/186)
-- Improve Error Message for Invalid Python code error [#187](https://github.com/scanapi/scanapi/pull/187)
-- Handle properly exit errors [#187](https://github.com/scanapi/scanapi/pull/187)
-- Update README.md [#191](https://github.com/scanapi/scanapi/pull/191)
+- Hero banner on README. [#180](https://github.com/scanapi/scanapi/pull/180)
+- Entry point to `scanapi:main`. [#172](https://github.com/scanapi/scanapi/pull/172)
+- `--spec-path` option to argument. [#172](https://github.com/scanapi/scanapi/pull/172)
+- Improve test results on report. [#186](https://github.com/scanapi/scanapi/pull/186)
+- Improve Error Message for Invalid Python code error. [#187](https://github.com/scanapi/scanapi/pull/187)
+- Handle properly exit errors. [#187](https://github.com/scanapi/scanapi/pull/187)
+- Update README.md. [#191](https://github.com/scanapi/scanapi/pull/191)
 
 ### Fixed
-- Duplicated status code row from report [#183](https://github.com/scanapi/scanapi/pull/183)
-- Sensitive information render on report [#183](https://github.com/scanapi/scanapi/pull/183)
+- Duplicated status code row from report. [#183](https://github.com/scanapi/scanapi/pull/183)
+- Sensitive information render on report. [#183](https://github.com/scanapi/scanapi/pull/183)
 
 ### Removed
-- Console Report [#175](https://github.com/scanapi/scanapi/pull/175)
-- Markdown Report [#179](https://github.com/scanapi/scanapi/pull/179)
-- `--reporter` option [#179](https://github.com/scanapi/scanapi/pull/179)
+- Console Report. [#175](https://github.com/scanapi/scanapi/pull/175)
+- Markdown Report. [#179](https://github.com/scanapi/scanapi/pull/179)
+- `--reporter` option. [#179](https://github.com/scanapi/scanapi/pull/179)
 
 ## [0.1.0] - 2020-05-14
 ### Added
-- Automated pypi deploy - [#144](https://github.com/scanapi/scanapi/pull/144)
+- Automated pypi deploy. [#144](https://github.com/scanapi/scanapi/pull/144)
 
 ## [0.0.19] - 2020-05-11
 ### Added
-- PATCH HTTP method - [#113](https://github.com/scanapi/scanapi/pull/113)
-- Ability to have API spec in multiples files - [#125](https://github.com/scanapi/scanapi/pull/125)
-- CLI `--config-path` option - [#128](https://github.com/scanapi/scanapi/pull/128)
-- CLI `--template-path` option - [#126](https://github.com/scanapi/scanapi/pull/126)
-- GitHub Action checking for missing changelog entry - [#134](https://github.com/scanapi/scanapi/pull/134)
+- PATCH HTTP method. [#113](https://github.com/scanapi/scanapi/pull/113)
+- Ability to have API spec in multiples files. [#125](https://github.com/scanapi/scanapi/pull/125)
+- CLI `--config-path` option. [#128](https://github.com/scanapi/scanapi/pull/128)
+- CLI `--template-path` option. [#126](https://github.com/scanapi/scanapi/pull/126)
+- GitHub Action checking for missing changelog entry. [#134](https://github.com/scanapi/scanapi/pull/134)
 
 ### Changed
-- Make markdown report a bit better - [#96](https://github.com/scanapi/scanapi/pull/96)
-- `base_url` keyword to `path` [#116](https://github.com/scanapi/scanapi/pull/116)
-- `namespace` keyword to `name` [#116](https://github.com/scanapi/scanapi/pull/116)
-- `method` keyword is not mandatory anymore for requests. Default is `get` [#116](https://github.com/scanapi/scanapi/pull/116)
-- Replaced `hide` key on report config by `hide-request` and `hide-response` [#116](https://github.com/scanapi/scanapi/pull/116)
-- Moved black check from CircleCI to github actions [#136](https://github.com/scanapi/scanapi/pull/136)
+- Make markdown report a bit better. [#96](https://github.com/scanapi/scanapi/pull/96)
+- `base_url` keyword to `path`. [#116](https://github.com/scanapi/scanapi/pull/116)
+- `namespace` keyword to `name`. [#116](https://github.com/scanapi/scanapi/pull/116)
+- `method` keyword is not mandatory anymore for requests. Default is `get`. [#116](https://github.com/scanapi/scanapi/pull/116)
+- Replaced `hide` key on report config by `hide-request` and `hide-response`. [#116](https://github.com/scanapi/scanapi/pull/116)
+- Moved black check from CircleCI to github actions. [#136](https://github.com/scanapi/scanapi/pull/136)
 
 ### Fixed
-- Cases where custom var has upper case letters [#99](https://github.com/scanapi/scanapi/pull/99)
+- Cases where custom var has upper case letters. [#99](https://github.com/scanapi/scanapi/pull/99)
 
 ### Removed
-- Request with no endpoints [#116](https://github.com/scanapi/scanapi/pull/116)
+- Request with no endpoints. [#116](https://github.com/scanapi/scanapi/pull/116)
 
 ## [0.0.18] - 2020-01-02
 ### Changed
-- Return params/headers None when request doesn't have params/headers [#87](https://github.com/scanapi/scanapi/pull/87)
+- Return params/headers None when request doesn't have params/headers. [#87](https://github.com/scanapi/scanapi/pull/87)
 
 ### Fixed
-- Report-example image not loading on PyPi [#86](https://github.com/scanapi/scanapi/pull/86)
+- Report-example image not loading on PyPi. [#86](https://github.com/scanapi/scanapi/pull/86)
 
 ## [0.0.17] - 2019-12-19
 ### Added
-- Added PyPI Test section to CONTRIBUTING.md
-- Added templates to pypi package - fix [#85](https://github.com/scanapi/scanapi/pull/85)
+- Added PyPI Test section to CONTRIBUTING.md.
+
+### Fixed
+- Templates on pypi package. [#85](https://github.com/scanapi/scanapi/pull/85)
 
 ## [0.0.16] - 2019-12-18
 ### Fixed
-- Fixed No module named 'scanapi.tree' [#83](https://github.com/scanapi/scanapi/pull/83)
+- Fixed No module named 'scanapi.tree'. [#83](https://github.com/scanapi/scanapi/pull/83)
 
 ## [0.0.15] - 2019-12-14
 ### Added
-- CodeCov Setup
-- CircleCI Setup
+- CodeCov Setup.
+- CircleCI Setup.
 
 ### Changed
-- Updated Documentation
-- Increased coverage
-- Used dot notation to access responses inside api spec
-- Renamed option report_path to output_path
-- Reporter option -r, --reporter [console|markdown|html]
+- Updated Documentation.
+- Increased coverage.
+- Used dot notation to access responses inside api spec.
+- Renamed option report_path to output_path.
+- Reporter option -r, --reporter [console|markdown|html].
 
 ### Fixed
-- Fixed join of urls to keep the last slash
+- Fixed join of urls to keep the last slash.
 
 ### Removed
-- Removed requirements files and put every dependency under setup.py
-- Removed dcvars key
+- Removed requirements files and put every dependency under setup.py.
+- Removed dcvars key.
 
 ## [0.0.14] - 2019-10-09
 ### Added
-- Add math, time, uuid and random libs to be used on api spec
+- Add math, time, uuid and random libs to be used on api spec.
 
 ## [0.0.13] - 2019-10-07
 ### Changed
-- Bumped version
+- Bumped version.
 
 ## [0.0.12] - 2019-08-15
 ### Added
-- Used env variables from os
+- Used env variables from os.
 
 ## [0.0.11] - 2019-08-09
 ### Added
-- Added Docker file
+- Added Docker file.
 
 ## [0.0.10] - 2019-08-09
 ### Added
-- Add logging
-- Option to hide headers fields
+- Add logging.
+- Option to hide headers fields.
 
 ### Fixed
-- Fix vars interpolation
+- Fix vars interpolation.
 
 [Unreleased]: https://github.com/camilamaia/scanapi/compare/v1.0.5...HEAD
 [1.0.5]: https://github.com/camilamaia/scanapi/compare/v1.0.4...v1.0.5

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ python-versions = "*"
 version = "0.7.12"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
 optional = false
@@ -97,7 +97,7 @@ description = "Validate configuration and produce human readable error messages.
 name = "cfgv"
 optional = false
 python-versions = ">=3.6.1"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 category = "main"
@@ -222,7 +222,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.25"
+version = "1.4.27"
 
 [package.extras]
 license = ["editdistance"]
@@ -733,7 +733,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.28"
+version = "20.0.30"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -775,7 +775,8 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "8088894dbbd3ff52e7e02a3c1e8ad3a92ac7fea9ae507e0b740256d7cbebe19c"
+content-hash = "79db8d6d7d207b2f721c5e9a1edc7964b32a44f51345c6b31c1002979b22c20b"
+lock-version = "1.0"
 python-versions = "^3.6.1"
 
 [metadata.files]
@@ -812,8 +813,8 @@ certifi = [
     {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
 ]
 cfgv = [
-    {file = "cfgv-3.1.0-py2.py3-none-any.whl", hash = "sha256:1ccf53320421aeeb915275a196e23b3b8ae87dea8ac6698b1638001d4a486d53"},
-    {file = "cfgv-3.1.0.tar.gz", hash = "sha256:c8e8f552ffcc6194f4e18dd4f68d9aef0c0d58ae7e7be8c82bee3c5e9edfa513"},
+    {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
+    {file = "cfgv-3.2.0.tar.gz", hash = "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -896,8 +897,8 @@ gitpython = [
     {file = "GitPython-3.1.7.tar.gz", hash = "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858"},
 ]
 identify = [
-    {file = "identify-1.4.25-py2.py3-none-any.whl", hash = "sha256:ccd88716b890ecbe10920659450a635d2d25de499b9a638525a48b48261d989b"},
-    {file = "identify-1.4.25.tar.gz", hash = "sha256:110ed090fec6bce1aabe3c72d9258a9de82207adeaa5a05cd75c635880312f9a"},
+    {file = "identify-1.4.27-py2.py3-none-any.whl", hash = "sha256:f9ea81ccbade4f12d5f3960522c508aabf31709a48efa4f6c6b700e0c7366ff2"},
+    {file = "identify-1.4.27.tar.gz", hash = "sha256:4c3646d765127b003d2bed8db1e125d68f5f83ad0cd85e21c908ef87a5e24be1"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1141,8 +1142,8 @@ urllib3 = [
     {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.28-py2.py3-none-any.whl", hash = "sha256:8f582a030156282a9ee9d319984b759a232b07f86048c1d6a9e394afa44e78c8"},
-    {file = "virtualenv-20.0.28.tar.gz", hash = "sha256:688a61d7976d82b92f7906c367e83bb4b3f0af96f8f75bfcd3da95608fe8ac6c"},
+    {file = "virtualenv-20.0.30-py2.py3-none-any.whl", hash = "sha256:8cd7b2a4850b003a11be2fc213e206419efab41115cc14bca20e69654f2ac08e"},
+    {file = "virtualenv-20.0.30.tar.gz", hash = "sha256:7b54fd606a1b85f83de49ad8d80dbec08e983a2d2f96685045b262ebc7481ee5"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ jinja2 = "2.11.2"
 pyyaml = "5.3.1"
 requests = "2.24.0"
 bandit = "^1.6.2"
+appdirs = "^1.4.4"
 
 [tool.poetry.dev-dependencies]
 codecov = "2.1.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "1.0.5-rc.1"
+version = "1.0.5-rc.2"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"

--- a/scanapi/__main__.py
+++ b/scanapi/__main__.py
@@ -1,6 +1,8 @@
 import click
 import logging
+import yaml
 
+from scanapi.exit_code import ExitCode
 from scanapi.scan import scan
 from scanapi.session import session
 from scanapi.settings import settings
@@ -58,5 +60,12 @@ def run(spec_path, output_path, config_path, template, log_level):
         "template": template,
     }
 
-    settings.save_preferences(**click_preferences)
+    try:
+        settings.save_preferences(**click_preferences)
+    except yaml.YAMLError as e:
+        error_message = "Error loading configuration file."
+        error_message = "{}\nPyYAML: {}".format(error_message, str(e))
+        logger.error(error_message)
+        raise SystemExit(ExitCode.USAGE_ERROR)
+
     scan()

--- a/scanapi/config_loader.py
+++ b/scanapi/config_loader.py
@@ -37,14 +37,7 @@ def construct_include(loader: Loader, node: yaml.Node) -> Any:
 
 
 def load_config_file(file_path):
-    """ Loads config file, checks extension of file - only .yaml, .yml and .json
-    are supported. If non-empty file exists reads data and returns it
-    """
-    extension = os.path.splitext(file_path)[-1]
-
-    if extension not in (".yaml", ".yml", ".json"):
-        raise FileFormatNotSupportedError(extension, file_path)
-
+    """ Loads configuration file. If non-empty file exists reads data and returns it """
     with open(file_path, "r") as stream:
         logger.info(f"Loading file {file_path}")
         data = yaml.load(stream, Loader)

--- a/scanapi/scan.py
+++ b/scanapi/scan.py
@@ -33,7 +33,9 @@ def scan():
         logger.error(error_message)
         raise SystemExit(ExitCode.USAGE_ERROR)
     except yaml.YAMLError as e:
-        logger.error(e)
+        error_message = "Error loading specification file."
+        error_message = "{}\nPyYAML: {}".format(error_message, str(e))
+        logger.error(error_message)
         raise SystemExit(ExitCode.USAGE_ERROR)
 
     try:

--- a/scanapi/settings.py
+++ b/scanapi/settings.py
@@ -4,10 +4,7 @@ import appdirs
 from scanapi.config_loader import load_config_file
 
 
-GLOBAL_CONFIG_PATH = os.path.join(
-    appdirs.site_config_dir("scanapi"),
-    "scanapi.conf",
-)
+GLOBAL_CONFIG_PATH = os.path.join(appdirs.site_config_dir("scanapi"), "scanapi.conf",)
 
 LOCAL_CONFIG_PATH = "./scanapi.conf"
 
@@ -25,21 +22,15 @@ class Settings(dict):
 
     def save_config_file_preferences(self, config_path=None):
         """ Saves the Settings object config file preferences. """
-        if not config_path and not self.has_local_config_file:
-            return
-
-        if os.path.isfile(GLOBAL_CONFIG_PATH):
-            global_config = load_config_file(GLOBAL_CONFIG_PATH)
-            self.update(**global_config)
-
-        if not config_path:
-            user_config = load_config_file(LOCAL_CONFIG_PATH)
+        if config_path:
+            self["config_path"] = config_path
+            self.update(**load_config_file(config_path))
+        elif self.has_local_config_file:
             self["config_path"] = LOCAL_CONFIG_PATH
-            self.update(**user_config)
-            return
-
-        user_config = load_config_file(config_path)
-        self.update(**user_config)
+            self.update(**load_config_file(LOCAL_CONFIG_PATH))
+        elif self.has_global_config_file:
+            self["config_path"] = GLOBAL_CONFIG_PATH
+            self.update(**load_config_file(GLOBAL_CONFIG_PATH))
 
     def save_click_preferences(self, **preferences):
         """ Saves all preference items to the Settings object. """

--- a/scanapi/settings.py
+++ b/scanapi/settings.py
@@ -49,10 +49,12 @@ class Settings(dict):
 
     @property
     def has_global_config_file(self):
+        """ Checks if there is a global config file. """
         return os.path.isfile(GLOBAL_CONFIG_PATH)
 
     @property
     def has_local_config_file(self):
+        """ Checks if there is a local config file. """
         return os.path.isfile(LOCAL_CONFIG_PATH)
 
 

--- a/scanapi/settings.py
+++ b/scanapi/settings.py
@@ -1,8 +1,15 @@
 import os
+import appdirs
 
 from scanapi.config_loader import load_config_file
 
-DEFAULT_CONFIG_PATH = ".scanapi.yaml"
+
+GLOBAL_CONFIG_PATH = os.path.join(
+    appdirs.site_config_dir("scanapi"),
+    "scanapi.conf",
+)
+
+LOCAL_CONFIG_PATH = "./scanapi.conf"
 
 
 class Settings(dict):
@@ -18,12 +25,16 @@ class Settings(dict):
 
     def save_config_file_preferences(self, config_path=None):
         """ Saves the Settings object config file preferences. """
-        if not config_path and not self.has_default_config_file:
+        if not config_path and not self.has_local_config_file:
             return
 
+        if os.path.isfile(GLOBAL_CONFIG_PATH):
+            global_config = load_config_file(GLOBAL_CONFIG_PATH)
+            self.update(**global_config)
+
         if not config_path:
-            user_config = load_config_file(DEFAULT_CONFIG_PATH)
-            self["config_path"] = DEFAULT_CONFIG_PATH
+            user_config = load_config_file(LOCAL_CONFIG_PATH)
+            self["config_path"] = LOCAL_CONFIG_PATH
             self.update(**user_config)
             return
 
@@ -46,9 +57,12 @@ class Settings(dict):
         self.save_click_preferences(**click_preferences)
 
     @property
-    def has_default_config_file(self):
-        """ Helper property that returns whether the default config path exists. """
-        return os.path.isfile(DEFAULT_CONFIG_PATH)
+    def has_global_config_file(self):
+        return os.path.isfile(GLOBAL_CONFIG_PATH)
+
+    @property
+    def has_local_config_file(self):
+        return os.path.isfile(LOCAL_CONFIG_PATH)
 
 
 settings = Settings()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,13 +1,22 @@
-import os
 from click.testing import CliRunner
+import logging
+import os
+import pytest
+import yaml
 
 from scanapi.__main__ import run
+
+log = logging.getLogger(__name__)
+runner = CliRunner()
+
+
+def yaml_error(*args, **kwargs):
+    raise yaml.YAMLError("error foo")
 
 
 class TestMain:
     class TestRun:
         def test_call_save_preferences(self, mocker):
-            runner = CliRunner()
             mock_save_preferences = mocker.patch(
                 "scanapi.settings.Settings.save_preferences"
             )
@@ -22,3 +31,16 @@ class TestMain:
                     "template": None,
                 }
             )
+
+        def test_should_log_error(self, mocker, caplog):
+            mock_save_preferences = mocker.patch(
+                "scanapi.settings.Settings.save_preferences", side_effect=yaml_error
+            )
+
+            with caplog.at_level(logging.ERROR):
+                result = runner.invoke(run, ["--output-path", "my_output.html"])
+
+                assert mock_save_preferences.called
+                assert result.exit_code == 4
+
+            assert "Error loading configuration file.\nPyYAML: error foo" in caplog.text

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -45,7 +45,7 @@ class TestScan:
                 "scanapi.scan.settings", {"spec_path": "invalid_path/scanapi.yaml"}
             )
             mocker.patch("scanapi.scan.load_config_file", side_effect=file_not_found)
-            with caplog.at_level(logging.INFO):
+            with caplog.at_level(logging.ERROR):
                 with pytest.raises(SystemExit) as excinfo:
                     scan()
 
@@ -61,7 +61,7 @@ class TestScan:
         def test_should_log_error(self, mocker, caplog):
             mocker.patch("scanapi.scan.load_config_file", side_effect=empty_config_file)
 
-            with caplog.at_level(logging.INFO):
+            with caplog.at_level(logging.ERROR):
                 with pytest.raises(SystemExit) as excinfo:
                     scan()
 
@@ -76,21 +76,21 @@ class TestScan:
     class TestWhenAPISpecFileHasAnError:
         def test_should_log_error(self, mocker, caplog):
             mocker.patch("scanapi.scan.load_config_file", side_effect=yaml_error)
-            with caplog.at_level(logging.INFO):
+            with caplog.at_level(logging.ERROR):
                 with pytest.raises(SystemExit) as excinfo:
                     scan()
 
                 assert excinfo.type == SystemExit
                 assert excinfo.value.code == 4
 
-            assert "error foo" in caplog.text
+            assert "Error loading specification file.\nPyYAML: error foo" in caplog.text
 
     class TestWhenAPISpecHasAnInvalidKey:
         def test_should_log_error(self, mocker, caplog):
             mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
             mock_load_config_file.return_value = {"blah": "blah"}
             mocker.patch("scanapi.scan.EndpointNode.__init__", side_effect=invalid_key)
-            with caplog.at_level(logging.INFO):
+            with caplog.at_level(logging.ERROR):
                 with pytest.raises(SystemExit) as excinfo:
                     scan()
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -4,12 +4,87 @@ import os
 from scanapi.settings import settings, LOCAL_CONFIG_PATH
 
 
+@pytest.fixture
+def mock_load_config_file(mocker):
+    return mocker.patch("scanapi.settings.load_config_file")
+
+
+@pytest.fixture
+def mock_has_local_config_file(mocker):
+    return mocker.patch(
+        "scanapi.settings.Settings.has_local_config_file",
+        mocker.PropertyMock(return_value=True),
+    )
+
+
+@pytest.fixture
+def mock_doesnt_have_local_config_file(mocker):
+    return mocker.patch(
+        "scanapi.settings.Settings.has_local_config_file",
+        mocker.PropertyMock(return_value=False),
+    )
+
+
+@pytest.fixture
+def mock_has_global_config_file(mocker):
+    return mocker.patch(
+        "scanapi.settings.Settings.has_global_config_file",
+        mocker.PropertyMock(return_value=True),
+    )
+
+
 class TestSettings:
     class TestInit:
         def test_should_init_with_default_values(self):
             assert settings["spec_path"] == "scanapi.yaml"
             assert settings["output_path"] is None
             assert settings["template"] is None
+
+    class TestSaveConfigFilePreferences:
+        @pytest.fixture(autouse=True)
+        def define_settings(self):
+            settings["spec_path"] = "path/spec-path.yaml"
+            settings["output_path"] = "path/output-path.yaml"
+            settings["template"] = None
+            settings["config_path"] = "path/config-path.yaml"
+
+        class TestWithConfigPath:
+            class TestWithConfigFile:
+                def test_should_save_preferences(self, mock_load_config_file):
+                    config_path = "my_config_file.yaml"
+                    settings.save_config_file_preferences(config_path)
+                    assert settings["config_path"].endswith("my_config_file.yaml")
+                    mock_load_config_file.assert_called_with("my_config_file.yaml")
+
+            class TestWithoutConfigFile:
+                def test_should_raise_exception(self):
+                    with pytest.raises(FileNotFoundError) as excinfo:
+                        config_path = "invalid/my_config_file.yaml"
+                        settings.save_config_file_preferences(config_path)
+
+                    assert (
+                        str(excinfo.value)
+                        == "[Errno 2] No such file or directory: 'invalid/my_config_file.yaml'"
+                    )
+
+        class TestHasLocalConfigFile:
+            def test_should_save_preferences(
+                self, mock_has_local_config_file, mock_load_config_file
+            ):
+                settings.save_config_file_preferences()
+                assert settings["config_path"].endswith("./scanapi.conf")
+                mock_load_config_file.assert_called_with("./scanapi.conf")
+
+        class TestHasGlobalConfigFile:
+            def test_should_save_preferences(
+                self,
+                mock_doesnt_have_local_config_file,
+                mock_has_global_config_file,
+                mock_load_config_file,
+            ):
+                settings.save_config_file_preferences()
+                assert settings["config_path"].endswith("scanapi/scanapi.conf")
+                assert mock_load_config_file.called
 
     class TestSavePreferences:
         @pytest.fixture
@@ -59,49 +134,24 @@ class TestSettings:
                 "config_path": "path/config-path",
             }
 
-    class TestSaveConfigFilePreferences:
-        @pytest.fixture(autouse=True)
-        def define_settings(self):
-            settings["spec_path"] = "path/spec-path.yaml"
-            settings["output_path"] = "path/output-path.yaml"
-            settings["template"] = None
-            settings["config_path"] = "path/config-path.yaml"
+    class TestHasGlobalConfigFile:
+        def test_returns_true(self, mocker):
+            mocker.patch("scanapi.settings.os.path.isfile", return_value=True)
 
-        class TestWithoutCustomConfigPath:
-            class TestWithDefaultConfigFile:
-                def test_should_save_preferences(self):
-                    with open(LOCAL_CONFIG_PATH, "w") as out_file:
-                        out_file.write("template: path/template.jinja")
+            assert settings.has_global_config_file is True
 
-                    settings.save_config_file_preferences()
-                    assert settings["template"] == "path/template.jinja"
+        def test_returns_false(self, mocker):
+            mocker.patch("scanapi.settings.os.path.isfile", return_value=False)
 
-                    os.remove(LOCAL_CONFIG_PATH)
+            assert settings.has_global_config_file is False
 
-            class TestWithoutDefaultConfigFile:
-                def test_should_not_change_preferences(self):
-                    settings.save_config_file_preferences()
-                    assert settings["spec_path"] == "path/spec-path.yaml"
+    class TestHasLocalConfigFile:
+        def test_returns_true(self, mocker):
+            mocker.patch("scanapi.settings.os.path.isfile", return_value=True)
 
-        class TestWithCustomConfigPath:
-            class TestWithConfigFile:
-                def test_should_save_preferences(self):
-                    config_path = "my_config_file.yaml"
-                    with open(config_path, "w") as out_file:
-                        out_file.write("template: template.jinja")
+            assert settings.has_local_config_file is True
 
-                    settings.save_config_file_preferences(config_path)
-                    assert settings["template"] == "template.jinja"
+        def test_returns_false(self, mocker):
+            mocker.patch("scanapi.settings.os.path.isfile", return_value=False)
 
-                    os.remove(config_path)
-
-            class TestWithoutConfigFile:
-                def test_should_raise_exception(self):
-                    with pytest.raises(FileNotFoundError) as excinfo:
-                        config_path = "invalid/my_config_file.yaml"
-                        settings.save_config_file_preferences(config_path)
-
-                    assert (
-                        str(excinfo.value)
-                        == "[Errno 2] No such file or directory: 'invalid/my_config_file.yaml'"
-                    )
+            assert settings.has_local_config_file is False

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 
-from scanapi.settings import settings, DEFAULT_CONFIG_PATH
+from scanapi.settings import settings, LOCAL_CONFIG_PATH
 
 
 class TestSettings:
@@ -70,13 +70,13 @@ class TestSettings:
         class TestWithoutCustomConfigPath:
             class TestWithDefaultConfigFile:
                 def test_should_save_preferences(self):
-                    with open(DEFAULT_CONFIG_PATH, "w") as out_file:
+                    with open(LOCAL_CONFIG_PATH, "w") as out_file:
                         out_file.write("template: path/template.jinja")
 
                     settings.save_config_file_preferences()
                     assert settings["template"] == "path/template.jinja"
 
-                    os.remove(DEFAULT_CONFIG_PATH)
+                    os.remove(LOCAL_CONFIG_PATH)
 
             class TestWithoutDefaultConfigFile:
                 def test_should_not_change_preferences(self):


### PR DESCRIPTION
Initial support for a different configuration filename and global configuration.

Created on top of: https://github.com/scanapi/scanapi/pull/225

closes #203
closes #131  