### PR TITLE
Fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated language use in README.md and CONTRIBUTING.md plus fix broken links. [#220](https://github.com/scanapi/scanapi/pull/220)
 - Removed unused sys import in scan.py and cleaned for PEP8 and spelling errors. [#217](https://github.com/scanapi/scanapi/pull/217)
 - Hide body sensitive information. [#238](https://github.com/scanapi/scanapi/pull/238)
-- Fix css issues with html template [#256](https://github.com/scanapi/scanapi/pull/256)
+- Fix css issues with html template. [#256](https://github.com/scanapi/scanapi/pull/256)
+- Fix when vars is declared and used in the same request.[#257](https://github.com/scanapi/scanapi/pull/257)
+- Fix when evaluated value is not string. [#257](https://github.com/scanapi/scanapi/pull/257)
 
 ### Removed
 - APIKeyMissingError. [#218](https://github.com/scanapi/scanapi/pull/218)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "1.0.5-rc.2"
+version = "2.0.0-rc.1"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"

--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -20,7 +20,7 @@ class CodeEvaluator:
 
     @classmethod
     def evaluate(cls, sequence, vars, is_a_test_case=False):
-        match = cls.python_code_pattern.search(sequence)
+        match = cls.python_code_pattern.search(str(sequence))
 
         if not match:
             return sequence

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -71,5 +71,8 @@ class StringEvaluator:
 
     @classmethod
     def replace_var_with_value(cls, sequence, variable, variable_value):
+        if variable == sequence:
+            return variable_value
+
         variable = re.escape(variable)
-        return re.sub(variable, variable_value, sequence)
+        return re.sub(variable, str(variable_value), sequence)

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -61,7 +61,7 @@ class EndpointNode:
 
     @property
     def path(self):
-        path = self.spec.get(PATH_KEY, "").strip()
+        path = str(self.spec.get(PATH_KEY, "")).strip()
         url = join_urls(self.parent.path, path) if self.parent else path
 
         return self.vars.evaluate(url)

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -96,6 +96,10 @@ class RequestNode:
         url = self.full_url_path
         logger.info("Making request %s %s", method, url)
 
+        self.endpoint.vars.update(
+            self.spec.get(VARS_KEY, {}), preevaluate=False,
+        )
+
         response = requests.request(
             method,
             url,

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -62,7 +62,7 @@ class RequestNode:
     @property
     def full_url_path(self):
         base_path = self.endpoint.path
-        path = self.spec.get(PATH_KEY, "")
+        path = str(self.spec.get(PATH_KEY, ""))
         full_url = join_urls(base_path, path)
 
         return self.endpoint.vars.evaluate(full_url)

--- a/tests/unit/evaluators/test_code_evaluator.py
+++ b/tests/unit/evaluators/test_code_evaluator.py
@@ -9,7 +9,7 @@ from scanapi.evaluators import CodeEvaluator, SpecEvaluator, StringEvaluator
 class TestCodeEvaluator:
     class TestEvaluate:
         class TestWhenDoesNotMatchThePattern:
-            test_data = ["no code", "${CODE}", "${code}", "{{code}}"]
+            test_data = ["no code", "${CODE}", "${code}", "{{code}}", 10, []]
 
             @pytest.mark.parametrize("sequence", test_data)
             def test_should_return_sequence(self, sequence):

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -145,6 +145,8 @@ class TestStringEvaluator:
                 "https://jsonplaceholder.typicode.com",
                 "https://jsonplaceholder.typicode.com/posts",
             ),
+            ("${product_id}", "${product_id}", 100, 100),
+            ("products/${product_id}", "${product_id}", 100, "products/100"),
         ]
 
         @pytest.mark.parametrize(

--- a/tests/unit/tree/test_endpoint_node.py
+++ b/tests/unit/tree/test_endpoint_node.py
@@ -19,7 +19,7 @@ class TestEndpointNode:
         def test_missing_required_keys(self):
             with pytest.raises(MissingMandatoryKeyError) as excinfo:
                 endpoints = [{}, {}]
-                node = EndpointNode({"endpoints": endpoints})
+                EndpointNode({"endpoints": endpoints})
 
             assert str(excinfo.value) == "Missing 'name' key(s) at 'endpoint' scope"
 
@@ -28,7 +28,6 @@ class TestEndpointNode:
 
     class TestName:
         def test_when_parent_has_no_name(self):
-            base_path = "http://foo.com"
             node = EndpointNode({"name": "child-node"}, parent=EndpointNode({}))
             assert node.name == "child-node"
 
@@ -73,6 +72,15 @@ class TestEndpointNode:
                 {"path": "/foo/", "name": "node", "requests": []}, parent=parent
             )
             assert node.path == "http://foo.com/foo/"
+
+        def test_with_path_not_string(self):
+            parent = EndpointNode(
+                {"path": "http://foo.com/", "name": "parent-node", "requests": [],}
+            )
+            node = EndpointNode(
+                {"path": 2, "name": "node", "requests": []}, parent=parent
+            )
+            assert node.path == "http://foo.com/2"
 
         def test_calls_evaluate(self, mocker, mock_evaluate):
             parent = EndpointNode(

--- a/tests/unit/tree/test_request_node.py
+++ b/tests/unit/tree/test_request_node.py
@@ -97,6 +97,13 @@ class TestRequestNode:
             request = RequestNode({"name": "foo", "path": "/foo/"}, endpoint=endpoint)
             assert request.full_url_path == "http://foo.com/foo/"
 
+        def test_with_trailintest_with_path_not_stringg_slashes(self):
+            endpoint = EndpointNode(
+                {"name": "foo", "requests": [{}], "path": "http://foo.com/"}
+            )
+            request = RequestNode({"name": "foo", "path": []}, endpoint=endpoint)
+            assert request.full_url_path == "http://foo.com/[]"
+
         def test_calls_evaluate(self, mocker, mock_evaluate):
             endpoint = EndpointNode(
                 {"name": "foo", "requests": [{}], "path": "http://foo.com/"}


### PR DESCRIPTION
- Fix when vars is declared and used in the same request
Example:

```yaml
requests:
  - name: new
    method: post
    vars:
      today: ${{datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')}}
    body:
      registered_at: ${today}
```
Before, the evaluation was not working. We were sending the value as `${today}`

- Fix when evaluated value is not string

Example

```yaml
requests:
  - name: new
    method: post
    path: 20
```

We were receiving the following error:
```shell
rary/Caches/pypoetry/virtualenvs/scanapi-KvDFA3Cq-py3.7/lib/python3.7/site-packages/jinja2/runtime.py", line 545, in __next__
    rv = next(self._iterator)
  File "/Users/camilamaia/workspace/scanapi-org/scanapi/scanapi/tree/endpoint_node.py", line 87, in run
    f"\nError to make request `{request.full_url_path}`. \n{str(e)}\n"
  File "/Users/camilamaia/workspace/scanapi-org/scanapi/scanapi/tree/request_node.py", line 66, in full_url_path
    full_url = join_urls(base_path, path)
  File "/Users/camilamaia/workspace/scanapi-org/scanapi/scanapi/utils.py", line 15, in join_urls
    second_url = second_url.lstrip("/")
AttributeError: 'int' object has no attribute 'lstrip'
```
