### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2020-08-25
 ### Added
 - JSON response is now properly rendered, instead of plain text. [#213](https://github.com/scanapi/scanapi/pull/213)
 - The report page now has a favicon. [#223](https://github.com/scanapi/scanapi/pull/223)
@@ -168,7 +170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v1.0.5...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/camilamaia/scanapi/compare/v1.0.5...v2.0.0
 [1.0.5]: https://github.com/camilamaia/scanapi/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/camilamaia/scanapi/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/camilamaia/scanapi/compare/v1.0.2...v1.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.0.0-rc.1"
+version = "2.0.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Added
- JSON response is now properly rendered, instead of plain text. [#213](https://github.com/scanapi/scanapi/pull/213)
- The report page now has a favicon. [#223](https://github.com/scanapi/scanapi/pull/223)
- Bandit security audit tool. [#219](https://github.com/scanapi/scanapi/pull/219)
- Add Sphinx auto-documentation. [#230](https://github.com/scanapi/scanapi/pull/230)
- Add workflow to package/publish to Test PyPi. [#239](https://github.com/scanapi/scanapi/pull/239)

### Changed
- Renamed `api.(yaml|json)` to `scanapi.yaml`. [#222](https://github.com/scanapi/scanapi/issues/20://github.com/scanapi/scanapi/pull/222)
- Remove top-level `api` key in `scanapi.yaml`. [#231](https://github.com/scanapi/scanapi/pull/231)
- Renamed `project-name`, `hide-request` and `hide-response` to use underscore. [#228](https://github.com/scanapi/scanapi/issues/228)
- Changed command `scanapi spec-file.yaml` to `scanapi run spec-file.yaml`. [#247](https://github.com/scanapi/scanapi/pull/247)
- Moved Documentation from README.md to the website. [#250](https://github.com/scanapi/scanapi/pull/250)
- Local and global configuration. [#254](https://github.com/scanapi/scanapi/pull/254)

### Fixed
- Updated language use in README.md and CONTRIBUTING.md plus fix broken links. [#220](https://github.com/scanapi/scanapi/pull/220)
- Removed unused sys import in scan.py and cleaned for PEP8 and spelling errors. [#217](https://github.com/scanapi/scanapi/pull/217)
- Hide body sensitive information. [#238](https://github.com/scanapi/scanapi/pull/238)
- Fix css issues with html template. [#256](https://github.com/scanapi/scanapi/pull/256)
- Fix when vars is declared and used in the same request.[#257](https://github.com/scanapi/scanapi/pull/257)
- Fix when evaluated value is not string. [#257](https://github.com/scanapi/scanapi/pull/257)

### Removed
- APIKeyMissingError. [#218](https://github.com/scanapi/scanapi/pull/218)