### PR TITLE
Implemented black action

### DIFF
--- a/.github/actions/black/Dockerfile
+++ b/.github/actions/black/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+
+RUN pip install black==19.10b0
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/black/entrypoint.sh
+++ b/.github/actions/black/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+sh -c "black $*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: "Black Code Formatter"
-        uses: "lgeiger/black-action@v1.0.1"
+        uses: "./.github/actions/black"
         with:
           args: ". --check"


### PR DESCRIPTION
`lgeiger/black-action` github action does not permit to set a specific version for Black. The action always install it using `pip install black`. See the code [here](https://github.com/lgeiger/black-action/blob/master/Dockerfile#L12)

For our project we fixed the version on [19.10b0](https://github.com/scanapi/scanapi/blob/f1a3b20892a3356f07a8688a63ee51c0c7bb3291/pyproject.toml#L33)

Because of that, our checks started failing. 

![image](https://user-images.githubusercontent.com/2728804/93030097-d86cf280-f5f6-11ea-9196-ec651c982e91.png)

https://github.com/scanapi/scanapi/pull/272/checks?check_run_id=1109422609

We could create a PR to implement this in the action, the same way we did for the `JRubics/poetry-publish` action, but the repository seems not having updates since last year.

Since the code is pretty simple, I decided to implement it inside our project.

closes https://github.com/scanapi/scanapi/issues/274