### PR TITLE
Set no `body` as None instead of `{}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed relative path to show absolute path to the report in CLI. [#277](https://github.com/scanapi/scanapi/pull/277)
 
+### Fixed
+- When there is no `body` specified, sending it as `None` instead of `{}`. [#280](https://github.com/scanapi/scanapi/pull/280)
+
 ## [2.0.0] - 2020-08-25
 ### Added
 - JSON response is now properly rendered, instead of plain text. [#213](https://github.com/scanapi/scanapi/pull/213)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -83,7 +83,7 @@ class RequestNode:
 
     @property
     def body(self):
-        body = self.spec.get(BODY_KEY, {})
+        body = self.spec.get(BODY_KEY)
 
         return self.endpoint.vars.evaluate(body)
 

--- a/tests/unit/tree/test_request_node.py
+++ b/tests/unit/tree/test_request_node.py
@@ -210,9 +210,9 @@ class TestRequestNode:
                 {"path": "http://foo.com", "name": "foo"},
                 endpoint=EndpointNode({"name": "foo", "requests": [{}]}),
             )
-            assert request.body == {}
+            assert request.body is None
 
-        def test_when_request_has_no_body(self):
+        def test_when_request_has_body(self):
             request = RequestNode(
                 {"body": {"abc": "def"}, "path": "http://foo.com", "name": "foo",},
                 endpoint=EndpointNode({"name": "foo", "requests": [{}]}),


### PR DESCRIPTION
On requests that have no `body`, ScanAPI is sending body as `{}` and Content-Length equals 2. The body should be None and the Content-Length should be 0.

## Before

![image](https://user-images.githubusercontent.com/2728804/94377997-18a29980-00fc-11eb-9e66-e76ef3528edf.png)

## After

![image](https://user-images.githubusercontent.com/2728804/94377999-1dffe400-00fc-11eb-8fb0-ecca7bedbce7.png)


Closes https://github.com/scanapi/scanapi/issues/262