### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.0] - 2020-10-06
 ### Added
 - Add a `delay` key option to perform a delay between each request. [#266](https://github.com/scanapi/scanapi/issues/266)
 
@@ -185,7 +187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/camilamaia/scanapi/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/camilamaia/scanapi/compare/v1.0.5...v2.0.0
 [1.0.5]: https://github.com/camilamaia/scanapi/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/camilamaia/scanapi/compare/v1.0.3...v1.0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.0.0-rc.16"
+version = "2.1.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Added
- Add a `delay` key option to perform a delay between each request. [#266](https://github.com/scanapi/scanapi/issues/266)

### Changed
- Changed relative path to show absolute path to the report in CLI. [#277](https://github.com/scanapi/scanapi/pull/277)
- Considering `-` (dash) in variable names. [#281](https://github.com/scanapi/scanapi/pull/281)
- Moved bandit to dev section [#285](https://github.com/scanapi/scanapi/pull/285)
- Increased Test coverage for `/scanapi/evaluators/spec_evaluator.py` [#291](https://github.com/scanapi/scanapi/pull/291)

### Fixed
- When there is no `body` specified, sending it as `None` instead of `{}`. [#280](https://github.com/scanapi/scanapi/pull/280)
- Removed unused imports. [#294](https://github.com/scanapi/scanapi/pull/294)