### PR TITLE
Add anchor link for each request in the report to make it easily shareable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added 
-- Add anchor link for each request in the report to make it easily shareable
+- Add anchor link for each request in the report to make it easily shareable. [#317](https://github.com/scanapi/scanapi/pull/317)
 
 ### Changed
 - Updated poetry-publish version to v1.3 [#311](https://github.com/scanapi/scanapi/pull/311)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Add anchor link for each request in the report to make it easily shareable
+
 ### Changed
 - Updated poetry-publish version to v1.3 [#311](https://github.com/scanapi/scanapi/pull/311)
 

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -401,7 +401,7 @@
         {% set endpoint_status_label = "P" if result["no_failure"] else "F" %}
         {% set request = response.request %}
 
-        <div class="endpoint">
+        <div class="endpoint" id="endpoint_{{ loop.index | string }}">
             <input type="checkbox" class="endpoint__checkbox" id="chck_{{ loop.index | string }}" />
             <label class="endpoint__title" for="chck_{{ loop.index | string }}">
                 <span class="endpoint__url"><span class="http_method">{{request.method}}</span> {{ request.path_url }}</span>
@@ -644,6 +644,28 @@
                     }
                 })
             })
+        </script>
+        <script>
+            function openAnchoredEndpoint(){
+                const url = window.location.href;
+                const containsAnEndpointAnchor = url.includes("#endpoint");
+                if(containsAnEndpointAnchor) {
+                    const elementId = url.split('#')[1];
+                    const element = document.getElementById(elementId);
+                    function scrollToElement() {
+                        element.scrollIntoView({
+                            block: 'start'
+                        });
+                    }
+                    function openElement() {
+                        element.getElementsByTagName('input')[0].click();
+                    };
+                    openElement();
+                    scrollToElement();
+                }
+                // e.currentTarget.getElementsByTagName('input')[0].click()
+            }
+            openAnchoredEndpoint();
         </script>
 </body>
 

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -663,7 +663,6 @@
                     openElement();
                     scrollToElement();
                 }
-                // e.currentTarget.getElementsByTagName('input')[0].click()
             }
             openAnchoredEndpoint();
         </script>


### PR DESCRIPTION
Hi everyone! I just implemented an solution for this issue: https://github.com/scanapi/scanapi/issues/260. The feature is already working, you just need to add the endpoint list index to the url and it's gonna open the page in the correct endpoint, e.g. url: ``Documents/scan-api/scanapi/scanapi-report.html#endpoint_4``.
I think that we have 2 more things to implement here: 
- would be nice to numerate the endpoints in the list, that way would be easy to the user to know the endpoint index.
- would be great to have an "share" button in the endpoint view, so the user can click on it an copy the custom url to clipboard.

I noticed another thing when editing the template HTML file, maybe would be more acessible if we start using an ``<ul>`` tag for the endpoints wrapper and ``<li>`` tags for the endpoints with proper key properties instead of ``<div>'s``.
Let me know your thoughts!
