### PR TITLE
Hide sensitive information in the URL Query Params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added flake8 check workflow on pull_request event [#321](https://github.com/scanapi/scanapi/pull/321)
+- Hide sensitive information in the URL Query Params [#304](https://github.com/scanapi/scanapi/pull/325)
 
 ### Changed
 - Updated poetry-publish version to v1.3 [#311](https://github.com/scanapi/scanapi/pull/311)

--- a/tests/unit/test_hide_utils.py
+++ b/tests/unit/test_hide_utils.py
@@ -104,6 +104,19 @@ class TestOverrideInfo:
             == b'{"id": "SENSITIVE_INFORMATION", "name": "Tarik", "yearsOfExperience": 2}'
         )
 
+    def test_overrides_params(self, response):
+        param = "test"
+        response.url = "http://test.com/users/details?test=test&test2=test&test=test2"
+        http_attr = "params"
+        secret_field = param
+
+        _override_info(response, http_attr, secret_field)
+
+        assert (
+            response.url
+            == "http://test.com/users/details?test=SENSITIVE_INFORMATION&test2=test&test=SENSITIVE_INFORMATION"
+        )
+
     def test_when_http_attr_does_not_have_the_field(self, response, mocker):
         response.headers = {"abc": "123"}
         http_attr = "headers"


### PR DESCRIPTION
Add a report configuration option to hide sensitive information in the url query params.
Solves #304.