### PR TITLE
Refactor on tests to use pytest-it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,17 @@
 repos:
   - repo: https://github.com/python/black
+    # It must match black's version that is inside pyproject.toml
     rev: 19.10b0
     hooks:
       - id: black
         language_version: python3
-        args: ["-l 80 . --exclude=.venv"]
+        args: ["-l 80", "--exclude=.venv"]
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.5.3
     hooks:
       - id: isort
   - repo: https://gitlab.com/pycqa/flake8
+    # It must match the flake8's version that is inside pyproject.toml
     rev: 3.8.4
     hooks:
       - id: flake8

--- a/tests/unit/evaluators/test_code_evaluator.py
+++ b/tests/unit/evaluators/test_code_evaluator.py
@@ -5,22 +5,29 @@ from scanapi.errors import InvalidPythonCodeError
 from scanapi.evaluators import CodeEvaluator
 
 
+@pytest.mark.describe("Test Code Evaluator")
 class TestCodeEvaluator:
+    @pytest.mark.describe("Test Evaluator")
     class TestEvaluate:
+        @pytest.mark.context("When Does Not Match The Pattern")
         class TestWhenDoesNotMatchThePattern:
             test_data = ["no code", "${CODE}", "${code}", "{{code}}", 10, []]
 
+            @pytest.mark.it("should return sequence")
             @pytest.mark.parametrize("sequence", test_data)
             def test_should_return_sequence(self, sequence):
                 assert CodeEvaluator.evaluate(sequence, {}) == sequence
 
+        @pytest.mark.context("Test When Matches The Pattern")
         class TestWhenMatchesThePattern:
+            @pytest.mark.context("When It Is A Test Case")
             class TestWhenItIsATestCase:
                 test_data = [
                     ("${{1 == 1}}", (True, None)),
                     ("${{1 == 4}}", (False, "1 == 4")),
                 ]
 
+                @pytest.mark.it("should return assert results")
                 @pytest.mark.parametrize("sequence, expected", test_data)
                 def test_should_return_assert_results(self, sequence, expected):
                     assert (
@@ -30,6 +37,7 @@ class TestCodeEvaluator:
                         == expected
                     )
 
+                @pytest.mark.context("When Code Contains Pre Saved Response")
                 class TestWhenCodeContainsPreSavedResponse:
                     @pytest.fixture
                     def response(self, requests_mock):
@@ -52,6 +60,7 @@ class TestCodeEvaluator:
                         ),
                     ]
 
+                    @pytest.mark.it("should return assert results")
                     @pytest.mark.parametrize("sequence, expected", test_data)
                     def test_should_return_assert_results(
                         self, sequence, expected, response
@@ -65,7 +74,9 @@ class TestCodeEvaluator:
                             == expected
                         )
 
+                @pytest.mark.context("When Code Breaks")
                 class TestWhenCodeBreaks:
+                    @pytest.mark.it("should raises invalid python code error")
                     def test_should_raises_invalid_python_code_error(self):
                         with pytest.raises(InvalidPythonCodeError) as excinfo:
                             CodeEvaluator.evaluate(
@@ -81,13 +92,16 @@ class TestCodeEvaluator:
                             "Code: response.url == 'abc'."
                         )
 
+            @pytest.mark.context("When It Is Not A Test Case")
             class TestWhenItIsNotATestCase:
                 test_data = [("${{1 + 1}}", "2"), ("${{'hi'*4}}", "hihihihi")]
 
+                @pytest.mark.it("should return evaluated code")
                 @pytest.mark.parametrize("sequence, expected", test_data)
                 def test_should_return_evaluated_code(self, sequence, expected):
                     assert CodeEvaluator.evaluate(sequence, {}) == expected
 
+                @pytest.mark.context("When Code Contains Pre Saved Response")
                 class TestWhenCodeContainsPreSavedResponse:
                     @pytest.fixture
                     def response(self, requests_mock):
@@ -102,6 +116,7 @@ class TestCodeEvaluator:
                         ("${{1+1}}", "2"),
                     ]
 
+                    @pytest.mark.it("should return evaluated code")
                     @pytest.mark.parametrize("sequence, expected", test_data)
                     def test_should_return_evaluated_code(
                         self, sequence, expected, response
@@ -113,7 +128,9 @@ class TestCodeEvaluator:
                             == expected
                         )
 
+                @pytest.mark.context("When Code Breaks")
                 class TestWhenCodeBreaks:
+                    @pytest.mark.it("should raises invalid python code error")
                     def test_should_raises_invalid_python_code_error(self):
                         with pytest.raises(InvalidPythonCodeError) as excinfo:
                             CodeEvaluator.evaluate("${{1/0}}", {})

--- a/tests/unit/evaluators/test_spec_evaluator.py
+++ b/tests/unit/evaluators/test_spec_evaluator.py
@@ -4,6 +4,7 @@ from scanapi.evaluators.spec_evaluator import SpecEvaluator
 from scanapi.tree import EndpointNode
 
 
+@pytest.mark.describe("Test Spec Evaluator")
 class TestSpecEvaluator:
     @pytest.fixture
     def mock_string_evaluate(self, mocker):
@@ -17,7 +18,9 @@ class TestSpecEvaluator:
         endpoint = EndpointNode({"name": "foo", "requests": [{}]}, parent)
         return SpecEvaluator(endpoint, {"name": "foo"})
 
+    @pytest.mark.describe("Test Evaluate String")
     class TestEvaluateString:
+        @pytest.mark.it("should call evaluate string")
         def test_should_call_evaluate_string(
             self, spec_evaluator, mock_string_evaluate
         ):
@@ -25,6 +28,7 @@ class TestSpecEvaluator:
             spec_evaluator.evaluate(string)
             assert mock_string_evaluate.called_once_with(string)
 
+        @pytest.mark.it("should call evaluate assertion string")
         def test_should_call_evaluate_assertion_string(
             self, spec_evaluator, mock_string_evaluate
         ):
@@ -32,13 +36,18 @@ class TestSpecEvaluator:
             spec_evaluator.evaluate_assertion(string)
             assert mock_string_evaluate.called_once_with(string)
 
+    @pytest.mark.describe("Test Evaluate Dict")
     class TestEvaluateDict:
+        @pytest.mark.context("When Dict Is Empty")
         class TestWhenDictIsEmpty:
+            @pytest.mark.it("return empty dict")
             def test_return_empty_dict(self, spec_evaluator):
                 evaluated_dict = spec_evaluator.evaluate({})
                 assert len(evaluated_dict) == 0
 
+        @pytest.mark.context("When Dict Is Not Empty")
         class TestWhenDictIsNotEmpty:
+            @pytest.mark.it("return evaluated dict")
             def test_return_evaluated_dict(
                 self, spec_evaluator, mocker, mock_string_evaluate
             ):
@@ -54,13 +63,18 @@ class TestSpecEvaluator:
                     ]
                 )
 
+    @pytest.mark.describe("Test Evaluate List")
     class TestEvaluateList:
+        @pytest.mark.context("When List Is Empty")
         class TestWhenListIsEmpty:
+            @pytest.mark.it("should return empty list")
             def test_return_empty_list(self, spec_evaluator):
                 evaluated_list = spec_evaluator.evaluate([])
                 assert len(evaluated_list) == 0
 
+        @pytest.mark.context("When List Is Not Empty")
         class TestWhenListIsNotEmpty:
+            @pytest.mark.it("should return evaluated list")
             def test_return_evaluated_list(
                 self, spec_evaluator, mocker, mock_string_evaluate
             ):
@@ -75,12 +89,15 @@ class TestSpecEvaluator:
                     ]
                 )
 
+    @pytest.mark.describe("Spec Evaluator Get Key")
     class TestSpecEvaluatorGetKey:
+        @pytest.mark.it("should return none")
         def test_should_return_none(self, spec_evaluator):
             key = "some_key"
             value = spec_evaluator.get(key)
             assert value is None
 
+        @pytest.mark.it("should return foo")
         def test_should_return_foo(self, spec_evaluator):
             key = "name"
             value = spec_evaluator.get(key)

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -6,7 +6,9 @@ from scanapi.errors import BadConfigurationError
 from scanapi.evaluators import StringEvaluator
 
 
+@pytest.mark.describe("Test String Evaluator")
 class TestStringEvaluator:
+    @pytest.mark.describe("Test Evaluate")
     class TestEvaluate:
         @pytest.fixture
         def mock__evaluate_env_var(self, mocker):
@@ -24,15 +26,19 @@ class TestStringEvaluator:
             mock_func.return_value = ""
             return mock_func
 
+        @pytest.mark.it("should call code evaluate")
         def test_calls_code_evaluate(self, mock_code_evaluate):
             StringEvaluator.evaluate("boo", {})
             mock_code_evaluate.assert_called_once_with("boo", {}, False)
 
+        @pytest.mark.it("should calls _evaluate_env_var")
         def test_calls__evaluate_env_var(self, mock__evaluate_env_var):
             StringEvaluator.evaluate("boo", {})
             mock__evaluate_env_var.assert_called_once_with("boo")
 
+    @pytest.mark.describe("Test Evaluate Env Var")
     class TestEvaluateEnvVar:
+        @pytest.mark.context("When Does Not Match The Pattern")
         class TestWhenDoesNotMatchThePattern:
             test_data = [
                 "no env var",
@@ -42,11 +48,14 @@ class TestStringEvaluator:
                 "${{VAR}}",
             ]
 
+            @pytest.mark.context("should return sequence")
             @pytest.mark.parametrize("sequence", test_data)
             def test_should_return_sequence(self, sequence):
                 assert StringEvaluator._evaluate_env_var(sequence) == sequence
 
+        @pytest.mark.context("When Matches The Pattern")
         class TestWhenMatchesThePattern:
+            @pytest.mark.context("When Env Var Is Set Properly")
             class TestWhenEnvVarIsSetProperly:
                 @pytest.fixture(autouse=True)
                 def base_url_env(self):
@@ -71,18 +80,21 @@ class TestStringEvaluator:
                     ),
                 ]
 
+                @pytest.mark.it("should return evaluated var")
                 @pytest.mark.parametrize("sequence, expected", test_data)
                 def test_should_return_evaluated_var(self, sequence, expected):
                     assert (
                         StringEvaluator._evaluate_env_var(sequence) == expected
                     )
 
+            @pytest.mark.context("When There Is No Corresponding Env Var")
             class TestWhenThereIsNoCorrespondingEnvVar:
                 @pytest.fixture(autouse=True)
                 def remove_base_url_env(self):
                     if os.environ.get("BASE_URL"):
                         del os.environ["BASE_URL"]
 
+                @pytest.mark.it("should raise bad configuration error")
                 def test_should_raise_bad_configuration_error(self):
                     with pytest.raises(BadConfigurationError) as excinfo:
                         StringEvaluator._evaluate_env_var("${BASE_URL}")
@@ -92,10 +104,13 @@ class TestStringEvaluator:
                         == "'BASE_URL' environment variable not set or badly configured"
                     )
 
+    @pytest.mark.describe("Test Evaluate Custom Var")
     class TestEvaluateCustomVar:
+        @pytest.mark.context("When Does Not Match The Pattern")
         class TestWhenDoesNotMatchThePattern:
             test_data = ["no var", "${ENV_VAR}", "${{code}}"]
 
+            @pytest.mark.it("should return sequence")
             @pytest.mark.parametrize("sequence", test_data)
             def test_should_return_sequence(self, sequence):
                 assert (
@@ -103,7 +118,11 @@ class TestStringEvaluator:
                     == sequence
                 )
 
+        @pytest.mark.context("When Matches The Pattern")
         class TestWhenMatchesThePattern:
+            @pytest.mark.context(
+                "When Code Does Not Contain The Pre Saved CustomVar"
+            )
             class TestWhenCodeDoesNotContainThePreSavedCustomVar:
                 test_data = [
                     ("${user_id}"),
@@ -113,6 +132,7 @@ class TestStringEvaluator:
                     ("${user_id} something after"),
                 ]
 
+                @pytest.mark.it("should return sequence")
                 @pytest.mark.parametrize("sequence", test_data)
                 def test_should_return_sequence(self, sequence):
                     assert (
@@ -120,6 +140,7 @@ class TestStringEvaluator:
                         == sequence
                     )
 
+            @pytest.mark.context("When Code Contains The Pre Saved CustomVar")
             class TestWhenCodeContainsThePreSavedCustomVar:
                 test_data = [
                     ("${user_id}", "10"),
@@ -133,6 +154,7 @@ class TestStringEvaluator:
                     ("${user_id} something after", "10 something after"),
                 ]
 
+                @pytest.mark.it("should return sequence")
                 @pytest.mark.parametrize("sequence, expected", test_data)
                 def test_should_return_sequence(self, sequence, expected):
                     vars = {
@@ -145,6 +167,7 @@ class TestStringEvaluator:
                         == expected
                     )
 
+    @pytest.mark.describe("Test Replace Var With Value")
     class TestReplaceVarWithValue:
         test_data = [
             ("${age}", "${age}", "45", "45"),
@@ -166,6 +189,7 @@ class TestStringEvaluator:
             ("products/${product_id}", "${product_id}", 100, "products/100"),
         ]
 
+        @pytest.mark.describe("should replace")
         @pytest.mark.parametrize(
             "sequence, variable, variable_value, expected", test_data
         )

--- a/tests/unit/tree/test_endpoint_node.py
+++ b/tests/unit/tree/test_endpoint_node.py
@@ -4,8 +4,11 @@ from scanapi.errors import MissingMandatoryKeyError
 from scanapi.tree import EndpointNode
 
 
+@pytest.mark.describe("Test Endpoint Node")
 class TestEndpointNode:
+    @pytest.mark.describe("Test Init")
     class TestInit:
+        @pytest.mark.it("should_create_children")
         def test_should_create_children(self):
             endpoints = [
                 {"name": "child-node-one", "requests": []},
@@ -20,6 +23,8 @@ class TestEndpointNode:
             )
             assert len(node.child_nodes) == len(endpoints)
 
+        @pytest.mark.context("When Required Keys are missing")
+        @pytest.mark.it("should raise Missing Mandatory Key Error")
         def test_missing_required_keys(self):
             with pytest.raises(MissingMandatoryKeyError) as excinfo:
                 endpoints = [{}, {}]
@@ -33,16 +38,22 @@ class TestEndpointNode:
         def test_no_required_keys_for_root(self):
             assert EndpointNode({})
 
+    @pytest.mark.describe("Test Name")
     class TestName:
+        @pytest.mark.context("When parent has no name")
+        @pytest.mark.it("should set child node's name")
         def test_when_parent_has_no_name(self):
             node = EndpointNode({"name": "child-node"}, parent=EndpointNode({}))
             assert node.name == "child-node"
 
+        @pytest.mark.context("When parent has name")
+        @pytest.mark.it("should set parent_name::child_name")
         def test_when_parent_has_name(self):
             parent = EndpointNode({"name": "root"})
             node = EndpointNode({"name": "child-node"}, parent=parent)
             assert node.name == "root::child-node"
 
+    @pytest.mark.describe("Test Path")
     class TestPath:
         @pytest.fixture
         def mock_evaluate(self, mocker):
@@ -53,6 +64,7 @@ class TestEndpointNode:
 
             return mock_func
 
+        @pytest.mark.context("When Parent Has No url")
         def test_when_parent_has_no_url(self):
             base_path = "http://foo.com"
             node = EndpointNode(
@@ -61,6 +73,7 @@ class TestEndpointNode:
             )
             assert node.path == base_path
 
+        @pytest.mark.context("When Parent Has url")
         def test_when_parent_has_url(self):
             base_path = "http://foo.com/api"
             parent = EndpointNode(
@@ -71,6 +84,7 @@ class TestEndpointNode:
             )
             assert node.path == "http://foo.com/api/foo"
 
+        @pytest.mark.context("When URL has trailing slashes")
         def test_with_trailing_slashes(self):
             parent = EndpointNode(
                 {
@@ -85,6 +99,7 @@ class TestEndpointNode:
             )
             assert node.path == "http://foo.com/foo/"
 
+        @pytest.mark.context("When path is not a string")
         def test_with_path_not_string(self):
             parent = EndpointNode(
                 {
@@ -98,6 +113,7 @@ class TestEndpointNode:
             )
             assert node.path == "http://foo.com/2"
 
+        @pytest.mark.it("should call evaluate")
         def test_calls_evaluate(self, mocker, mock_evaluate):
             parent = EndpointNode(
                 {
@@ -115,7 +131,9 @@ class TestEndpointNode:
 
             mock_evaluate.assert_has_calls(calls)
 
+    @pytest.mark.describe("Test Headers")
     class TestHeaders:
+        @pytest.mark.context("When parent has no headers")
         def test_when_parent_has_no_headers(self):
             headers = {"abc": "def"}
             node = EndpointNode(
@@ -124,6 +142,7 @@ class TestEndpointNode:
             )
             assert node.headers == headers
 
+        @pytest.mark.context("When parent has headers")
         def test_when_parent_has_headers(self):
             headers = {"abc": "def"}
             parent_headers = {"xxx": "www"}
@@ -139,6 +158,7 @@ class TestEndpointNode:
             )
             assert node.headers == {"abc": "def", "xxx": "www"}
 
+        @pytest.mark.context("When parent has repeated keys")
         def test_when_parent_has_repeated_keys(self):
             headers = {"abc": "def"}
             parent_headers = {"xxx": "www", "abc": "zxc"}
@@ -154,7 +174,9 @@ class TestEndpointNode:
             )
             assert node.headers == {"abc": "def", "xxx": "www"}
 
+    @pytest.mark.describe("Test Params")
     class TestParams:
+        @pytest.mark.context("When parent has no params")
         def test_when_parent_has_no_params(self):
             params = {"abc": "def"}
             node = EndpointNode(
@@ -163,6 +185,7 @@ class TestEndpointNode:
             )
             assert node.params == params
 
+        @pytest.mark.context("When parent has params")
         def test_when_parent_has_params(self):
             params = {"abc": "def"}
             parent_params = {"xxx": "www"}
@@ -178,6 +201,7 @@ class TestEndpointNode:
             )
             assert node.params == {"abc": "def", "xxx": "www"}
 
+        @pytest.mark.context("When parent has repeated keys")
         def test_when_parent_has_repeated_keys(self):
             params = {"abc": "def"}
             parent_params = {"xxx": "www", "abc": "zxc"}
@@ -193,15 +217,19 @@ class TestEndpointNode:
             )
             assert node.params == {"abc": "def", "xxx": "www"}
 
+    @pytest.mark.describe("Test Delay")
     class TestDelay:
+        @pytest.mark.context("When node has no delay")
         def test_when_node_has_no_delay(self):
             node = EndpointNode({"name": "node"})
             assert node.delay == 0
 
+        @pytest.mark.context("When node has delay")
         def test_when_node_has_delay(self):
             node = EndpointNode({"name": "node", "delay": 1})
             assert node.delay == 1
 
+        @pytest.mark.context("When parent has delay")
         def test_when_parent_has_delay(self):
             node = EndpointNode(
                 {"name": "node"},
@@ -209,6 +237,7 @@ class TestEndpointNode:
             )
             assert node.delay == 2
 
+        @pytest.mark.context("When both node and parent have delay")
         def test_when_both_node_and_parent_have_delay(self):
             node = EndpointNode(
                 {"name": "node", "delay": 3},
@@ -216,14 +245,17 @@ class TestEndpointNode:
             )
             assert node.delay == 3
 
+    @pytest.mark.describe("Test Run")
     class TestRun:
         pass  # TODO
 
+    @pytest.mark.describe("Test Validate")
     class TestValidate:
         @pytest.fixture()
         def mock_validate_keys(self, mocker):
             return mocker.patch("scanapi.tree.endpoint_node.validate_keys")
 
+        @pytest.mark.it("should call validate keys")
         def test_should_call_validate_keys(self, mock_validate_keys):
             spec = {
                 "headers": {"foo": "bar"},
@@ -254,10 +286,13 @@ class TestEndpointNode:
             assert "name" in keys
             assert "path" in keys
 
+    @pytest.mark.describe("Test Get Specs")
     class TestGetSpecs:
         pass  # TODO
 
+    @pytest.mark.describe("Test Get Requests")
     class TestGetRequests:
+        @pytest.mark.context("When node has children")
         def test_when_node_has_children(self):
             node = EndpointNode(
                 {


### PR DESCRIPTION
## Refactor on tests to use pytest-it

- tests/unit/evaluators/test_code_evaluator.py
- tests/unit/evaluators/test_spec_evaluator.py
- tests/unit/evaluators/test_string_evaluator.py
- tests/unit/tree/test_endpoint_node.py

Related to #339 