### PR TITLE
Update poetry-publish version

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -18,7 +18,7 @@ jobs:
       #   run: |
       #     pip install --upgrade pip
       - name: Build and publish to test pypi
-        uses: JRubics/poetry-publish@v1.5
+        uses: JRubics/poetry-publish@v1.6
         with:
           python_version: "3.6"
           poetry_version: ">=0.12"


### PR DESCRIPTION
I updated the version, but the build still fails. It is now because scanapi-2.1.0-py3-none-any.whl package already exists at test.pypi.org so I think we've fixed the problem with cryptography package :)