### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.0] - 2021-04-22
 ### Added
 - Hide sensitive information in the URL Query Params [#304](https://github.com/scanapi/scanapi/pull/325)
 - Anchor link for each request in the report to make it easily shareable. [#317](https://github.com/scanapi/scanapi/pull/317)
@@ -196,7 +198,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/camilamaia/scanapi/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/camilamaia/scanapi/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/camilamaia/scanapi/compare/v1.0.5...v2.0.0
 [1.0.5]: https://github.com/camilamaia/scanapi/compare/v1.0.4...v1.0.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN pip install scanapi==2.1.0
+RUN pip install scanapi==2.2.0
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.1.0"
+version = "2.2.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Added
- Hide sensitive information in the URL Query Params [#304](https://github.com/scanapi/scanapi/pull/325)
- Anchor link for each request in the report to make it easily shareable. [#317](https://github.com/scanapi/scanapi/pull/317)
- Support to HTTP methods HEAD and OPTIONS [#350](https://github.com/scanapi/scanapi/pull/350)
- The `retry` key under requests to setup retry for requests. [#298](https://github.com/scanapi/scanapi/issues/298)

### Fixed
- Curl command [#330](https://github.com/scanapi/scanapi/pull/330)
- Render body according to its request content type [#331](https://github.com/scanapi/scanapi/pull/331)
