### PR TITLE
Added request name to results variable passed to report (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Request name to report. [#390](https://github.com/scanapi/scanapi/pull/390)
 - Show on report the scanapi version used to generate it. [#386](https://github.com/scanapi/scanapi/pull/386)
 - Link icon to copy anchor URL. [#398](https://github.com/scanapi/scanapi/pull/398)
 

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -298,6 +298,12 @@
             color: red;
         }
 
+        .endpoint__request_node_name {
+            font-size: 16px;
+            padding: 0 10px;
+            font-style: italic;
+        }
+
         /* END -- ENDPOINT */
 
         /* TESTS SUMMARY */
@@ -422,6 +428,7 @@
                 <span class="endpoint__url">
                     <img data-anchor="endpoint_{{ loop.index | string }}" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
                     <span class="http_method">{{request.method}}</span> {{ request.path_url }}
+                    <span class="endpoint__request_node_name">{{ result.request_node_name }}</span>
                 </span>
                 <span class="endpoint__titleInfo">
                     {{ response.status_code }}

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -117,7 +117,7 @@ class RequestNode:
     def run(self):
         """Make HTTP requests and generating test results for the given URLs.
         Returns:
-            [dict]: HTTP response and test results with request node name, 
+            [dict]: HTTP response and test results with request node name,
             to be used by the report template.
         """
         time.sleep(self.delay / 1000)

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -115,9 +115,9 @@ class RequestNode:
         return self.spec.get(RETRY_KEY)
 
     def run(self):
-        """Run request and yours tests.
+        """Make HTTP requests and generating test results for the given URLs.
         Returns:
-            [dict]: values required to render template.
+            [dict]: HTTP response and test results with request node name, to be used by the report template.
         """
         time.sleep(self.delay / 1000)
 

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -117,7 +117,8 @@ class RequestNode:
     def run(self):
         """Make HTTP requests and generating test results for the given URLs.
         Returns:
-            [dict]: HTTP response and test results with request node name, to be used by the report template.
+            [dict]: HTTP response and test results with request node name, 
+            to be used by the report template.
         """
         time.sleep(self.delay / 1000)
 

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -115,6 +115,10 @@ class RequestNode:
         return self.spec.get(RETRY_KEY)
 
     def run(self):
+        """Run request and yours tests.
+        Returns:
+            [dict]: values required to render template.
+        """
         time.sleep(self.delay / 1000)
 
         method = self.http_method
@@ -153,6 +157,7 @@ class RequestNode:
                     for test_result in tests_results
                 ]
             ),
+            "request_node_name": self.name,
         }
 
     def _run_tests(self):

--- a/tests/unit/tree/request_node/test_run.py
+++ b/tests/unit/tree/request_node/test_run.py
@@ -21,9 +21,9 @@ class TestRun:
     @mark.it("should call the request method")
     def test_calls_request(self, mock_session, mock_time_sleep):
         request = RequestNode(
-            {"path": "http://foo.com", "name": "foo"},
+            {"path": "http://foo.com", "name": "request_name"},
             endpoint=EndpointNode(
-                {"name": "foo", "requests": [{}], "delay": 1}
+                {"name": "endpoint_name", "requests": [{}], "delay": 1}
             ),
         )
         result = request.run()
@@ -43,6 +43,7 @@ class TestRun:
             "response": mock_session().request(),
             "tests_results": [],
             "no_failure": True,
+            "request_node_name": "request_name",
         }
 
     test_data = [
@@ -57,8 +58,8 @@ class TestRun:
     ):
         mock_run_tests.return_value = test_results
         request = RequestNode(
-            {"name": "foo"},
-            endpoint=EndpointNode({"name": "foo", "requests": [{}]}),
+            {"name": "request_name"},
+            endpoint=EndpointNode({"name": "endpoint_name", "requests": [{}]}),
         )
 
         result = request.run()
@@ -67,4 +68,5 @@ class TestRun:
             "response": mock_session().request(),
             "tests_results": test_results,
             "no_failure": expected_no_failure,
+            "request_node_name": "request_name",
         }


### PR DESCRIPTION
## Description
Show request names in the report.

## Motivation behind this PR?
Requests for different purposes with the same paths.

## What type of change is this?
Feature

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #354 
