### PR TITLE
Fix Changelog Lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ jobs:
 
 workflows:
   version: 2
-  master:
+  main:
     jobs:
       - changelog-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Added
+### Added
 - Show on report the scanapi version used to generate it. [#386](https://github.com/scanapi/scanapi/pull/386)
 
 ## [2.3.0] - 2021-05-25


### PR DESCRIPTION
## Description
[Changelog Lint Workflow is failing on master.](https://app.circleci.com/pipelines/github/scanapi/scanapi/780/workflows/6bfafaf3-5d62-4781-9ab0-4a0af8a533eb/jobs/1196). This PR fixes it.

## Motivation behind this PR?
Added a missing `#` to the `Added` section, in order to make the changelog lint pass. We want to have the changelog file always in the same format to keep the consistence.

## What type of change is this?
Bug fix

## Checklist

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] **N/A** - I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] **N/A** - I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [ ] **N/A** - I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
Closes #389  
