### PR TITLE
Fix making request that has no body and there is a hide_request::body config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Show on report the scanapi version used to generate it. [#386](https://github.com/scanapi/scanapi/pull/386)
 
+### Fixed
+- Error making request when request has no body and there is a `report::hide_request::body` configuration. [#393](https://github.com/scanapi/scanapi/pull/393)
+
 ## [2.3.0] - 2021-05-25
 ### Added
 - `--version` command to return current scanapi version. [#372](https://github.com/scanapi/scanapi/pull/372)

--- a/scanapi/hide_utils.py
+++ b/scanapi/hide_utils.py
@@ -13,7 +13,14 @@ SENSITIVE_INFO_SUBSTITUTION_FLAG = "SENSITIVE_INFORMATION"
 
 
 def hide_sensitive_info(response):
-    """ Takes response and begins the hiding of sensitive data process """
+    """Takes response and hides the sensitive data replacing the info with the string
+    `SENSITIVE_INFORMATION`.
+
+        Args:
+            response [requests.models.Response]: the response that has information to be hidden.
+
+    """
+
     report_settings = settings.get("report", {})
     request = response.request
     request_settings = report_settings.get("hide_request", {})
@@ -25,8 +32,16 @@ def hide_sensitive_info(response):
 
 def _hide(http_msg, hide_settings):
     """Private method that finds all sensitive information attributes and calls _override_info
-    to have sensitive data replaced
+    to have sensitive data replaced.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        hide_settings [dic]: the fields that need to be hidden for each http attribute (body,
+        headers, url params)
+
     """
+
     for http_attr in hide_settings:
         secret_fields = hide_settings[http_attr]
         for field in secret_fields:
@@ -34,19 +49,37 @@ def _hide(http_msg, hide_settings):
 
 
 def _override_info(http_msg, http_attr, secret_field):
-    """ Private method that substitutes sensitive data with string 'SENSITIVE_INFORMATION' """
+    """Private method that substitutes sensitive data with string 'SENSITIVE_INFORMATION'.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        http_attr [string]: the http_attr that has a field to be hidden: body, headers, url or
+        params
+        secret_field [string]: the secret field which its value must be hidden.
+
+    """
 
     if http_attr == URL:
         _override_url(http_msg, secret_field)
     elif http_attr == HEADERS:
         _override_headers(http_msg, secret_field)
-    elif http_attr == BODY:
-        _override_body(http_msg, secret_field)
     elif http_attr == PARAMS:
         _override_params(http_msg, secret_field)
+    elif http_attr == BODY:
+        _override_body(http_msg, secret_field)
 
 
 def _override_url(http_msg, secret_field):
+    """Private method that substitutes sensitive data with string 'SENSITIVE_INFORMATION' in URLs.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        secret_field [string]: the secret field which its value must be hidden in the URL.
+
+    """
+
     url_parsed = urlparse(http_msg.url)
     if secret_field in url_parsed.path:
         new_url = url_parsed._replace(
@@ -59,23 +92,33 @@ def _override_url(http_msg, secret_field):
 
 
 def _override_headers(http_msg, secret_field):
+    """Private method that substitutes sensitive data with string 'SENSITIVE_INFORMATION' in the
+    request/response headers.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        secret_field [string]: the secret field which its value must be hidden in the
+        request/response headers.
+
+    """
+
     if secret_field in http_msg.headers:
         http_msg.headers[secret_field] = SENSITIVE_INFO_SUBSTITUTION_FLAG
 
 
-def _override_body(http_msg, secret_field):
-    try:
-        has_body = hasattr(http_msg, "body")
-        body = json.loads(getattr(http_msg, "body" if has_body else "content"))
-        if secret_field in body:
-            body[secret_field] = SENSITIVE_INFO_SUBSTITUTION_FLAG
-            value = json.dumps(body).encode("utf-8")
-            setattr(http_msg, "body" if has_body else "_content", value)
-    except JSONDecodeError:
-        pass
-
-
 def _override_params(http_msg, secret_field):
+    """Private method that substitutes sensitive data with string 'SENSITIVE_INFORMATION' in the
+    request/response params.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        secret_field [string]: the secret field which its value must be hidden in the
+        request/response params.
+
+    """
+
     url_parsed = urlparse(http_msg.url)
     query_parsed = parse_qs(url_parsed.query)
     param_values_list = query_parsed.get(secret_field, [])
@@ -91,3 +134,93 @@ def _override_params(http_msg, secret_field):
 
     new_url = urlunparse(url_parsed)
     http_msg.url = new_url
+
+
+def _override_body(http_msg, secret_field):
+    """Private method that substitutes sensitive data with string 'SENSITIVE_INFORMATION' in the
+    request/response body/content.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        secret_field [string]: the secret field which its value must be hidden in the
+        request/response body/content.
+
+    """
+
+    body = _get_json_body(http_msg)
+
+    if body and secret_field in body:
+        body[secret_field] = SENSITIVE_INFO_SUBSTITUTION_FLAG
+        _set_json_body(http_msg, body)
+
+
+def _get_json_body(http_msg):
+    """Private method that gets the json body/content of a request/response.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+
+    Returns:
+        [dict]: the json body/content of the request/response.
+    """
+
+    try:
+        body = _get_body(http_msg)
+
+        if not body:
+            return
+
+        return json.loads(body)
+
+    except JSONDecodeError:
+        pass
+
+
+def _get_body(http_msg):
+    """Private method that gets the body/content of a request/response.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+
+    Returns:
+        [bytes]: the body/content of the request/response.
+    """
+
+    if not hasattr(http_msg, "body"):
+        return http_msg._content
+
+    return http_msg.body
+
+
+def _set_json_body(http_msg, value):
+    """Private method that sets the json body/content of a request/response.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        value [dict]: the json body/content of the request/response.
+
+    """
+
+    value = json.dumps(value).encode("utf-8")
+    _set_body(http_msg, value)
+
+
+def _set_body(http_msg, value):
+    """Private method that sets the body/content of a request/response.
+
+    Args:
+        http_msg [requests.models.PreparedRequest / requests.models.Response]: the request or the
+        response that has information to be hidden.
+        value [bytes]: the body/content of the request/response.
+
+    """
+
+    if not hasattr(http_msg, "body"):
+        http_msg._content = value
+        return
+
+    http_msg.body = value

--- a/tests/unit/test_hide_utils.py
+++ b/tests/unit/test_hide_utils.py
@@ -114,6 +114,22 @@ class TestOverrideInfo:
 
         assert response.headers["abc"] == "SENSITIVE_INFORMATION"
 
+    @mark.it("should overrides params")
+    def test_overrides_params(self, response):
+        param = "test"
+        response.url = (
+            "http://test.com/users/details?test=test&test2=test&test=test2"
+        )
+        http_attr = "params"
+        secret_field = param
+
+        _override_info(response, http_attr, secret_field)
+
+        assert (
+            response.url
+            == "http://test.com/users/details?test=SENSITIVE_INFORMATION&test2=test&test=SENSITIVE_INFORMATION"
+        )
+
     @mark.it("should overrides body")
     def test_overrides_body(self, response):
         response.body = (
@@ -157,21 +173,25 @@ class TestOverrideInfo:
 
         assert response.content == b"{}"
 
-    @mark.it("should overrides params")
-    def test_overrides_params(self, response):
-        param = "test"
-        response.url = (
-            "http://test.com/users/details?test=test&test2=test&test=test2"
-        )
-        http_attr = "params"
-        secret_field = param
+    @mark.it("should skip when body is None")
+    def test_skip_when_body_is_none(self, response):
+        response.body = None
+        http_attr = "body"
+        secret_field = "id"
 
         _override_info(response, http_attr, secret_field)
 
-        assert (
-            response.url
-            == "http://test.com/users/details?test=SENSITIVE_INFORMATION&test2=test&test=SENSITIVE_INFORMATION"
-        )
+        assert response.body is None
+
+    @mark.it("should skip when content is None")
+    def test_skip_when_content_is_none(self, response):
+        response._content = None
+        http_attr = "body"
+        secret_field = "id"
+
+        _override_info(response, http_attr, secret_field)
+
+        assert response._content is None
 
     @mark.context("when http attr does not have the field")
     @mark.it("should not change the http attr")


### PR DESCRIPTION
## Description
Fix error making request when request has no body and there is a `report::hide_request::body` configuration.

## Motivation behind this PR?
Closes #392 

## What type of change is this?
Bug fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue

Closes 392
