### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.0] - 2021-06-11
 ### Added
 - Request name to report. [#390](https://github.com/scanapi/scanapi/pull/390)
 - Show on report the scanapi version used to generate it. [#386](https://github.com/scanapi/scanapi/pull/386)
@@ -212,7 +214,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/camilamaia/scanapi/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/camilamaia/scanapi/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/camilamaia/scanapi/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/camilamaia/scanapi/compare/v2.0.0...v2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN pip install scanapi==2.3.0
+RUN pip install scanapi==2.4.0
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.3.0"
+version = "2.4.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -58,13 +58,23 @@ class TestWrite:
         return mocker.patch("scanapi.reporter.session")
 
     @fixture
+    def mock_get_distribution(self, mocker):
+        class MockDistro:
+            @property
+            def version(self):
+                return "2.0.0"
+
+        mock_distr = mocker.patch("scanapi.reporter.get_distribution")
+        mock_distr.return_value = MockDistro()
+
+    @fixture
     def context(self, mocked__session):
         return {
             "now": FakeDatetime(2020, 5, 12, 11, 32, 34),
             "project_name": "",
             "results": fake_results,
             "session": mocked__session,
-            "scanapi_version": "2.3.0",
+            "scanapi_version": "2.0.0",
         }
 
     @fixture
@@ -75,7 +85,13 @@ class TestWrite:
 
     @mark.it("should write to default output")
     def test_should_write_to_default_output(
-        self, mocker, mocked__render, mocked__open, mocked__session, context,
+        self,
+        mocker,
+        mocked__render,
+        mocked__open,
+        mocked__session,
+        mock_get_distribution,
+        context,
     ):
         mocked__render.return_value = "ScanAPI Report"
         reporter = Reporter()
@@ -89,7 +105,13 @@ class TestWrite:
 
     @mark.it("should write to custom output")
     def test_should_write_to_custom_output(
-        self, mocker, mocked__render, mocked__open, mocked__session, context,
+        self,
+        mocker,
+        mocked__render,
+        mocked__open,
+        mocked__session,
+        mock_get_distribution,
+        context,
     ):
         mocked__render.return_value = "ScanAPI Report"
         reporter = Reporter("./custom/report-output.html", "html")
@@ -103,7 +125,13 @@ class TestWrite:
 
     @mark.it("should handle custom templates")
     def test_should_handle_custom_templates(
-        self, mocker, mocked__render, mocked__open, mocked__session, context,
+        self,
+        mocker,
+        mocked__render,
+        mocked__open,
+        mocked__session,
+        mock_get_distribution,
+        context,
     ):
         mocked__render.return_value = "ScanAPI Report"
         reporter = Reporter(template="my-template.html")


### PR DESCRIPTION
### Added
- Request name to report. [#390](https://github.com/scanapi/scanapi/pull/390)
- Show on report the scanapi version used to generate it. [#386](https://github.com/scanapi/scanapi/pull/386)
- Link icon to copy anchor URL. [#398](https://github.com/scanapi/scanapi/pull/398)

### Fixed
- Error making request when request has no body and there is a `report::hide_request::body` configuration. [#393](https://github.com/scanapi/scanapi/pull/393)