### PR TITLE
Enable autoescape in template_render

### DIFF
--- a/scanapi/template_render.py
+++ b/scanapi/template_render.py
@@ -5,7 +5,7 @@ from jinja2 import Environment, FileSystemLoader, PackageLoader
 def render(template_path, context, is_external=False):
     """ Controller function that handles the Jinga2 rending of the template"""
     loader = _loader(is_external)
-    env = Environment(loader=loader)
+    env = Environment(loader=loader, autoescape=True)
     env.filters["curlify"] = curlify2.to_curl
     env.filters["render_body"] = render_body
     chosen_template = env.get_template(template_path)


### PR DESCRIPTION
* updated Environment(loader=loader) -> Environment(loader=loader, autoescape=True)

Closes: https://github.com/scanapi/scanapi/issues/401

## Description
<!--- Describe your changes -->
Enable autoescape in `scanapi/template_render,py::render(template_path, context, is_external=False)` 

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
Using Jinja2 templates without autoescaping enabled leaves application vulnerable to [XSS attacks](https://owasp.org/www-project-top-ten/2017/A72017-Cross-SiteScripting_(XSS).

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Bug Fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes 401
