### PR TITLE
Fix: No whitespaces allowed surrounding docstring text

### DIFF
--- a/scanapi/config_loader.py
+++ b/scanapi/config_loader.py
@@ -19,16 +19,16 @@ class Loader(yaml.SafeLoader):
     def __init__(self, stream: IO) -> None:
         """Initialise Loader."""
         try:
-            self._root = os.path.split(stream.name)[0]
+            self.root = os.path.split(stream.name)[0]
         except AttributeError:
-            self._root = os.path.curdir
+            self.root = os.path.curdir
 
         super().__init__(stream)
 
 
 def construct_include(loader: Loader, node: yaml.Node) -> Any:
     """Include file referenced at node."""
-    relative_path = os.path.join(loader._root, loader.construct_scalar(node))
+    relative_path = os.path.join(loader.root, loader.construct_scalar(node))
     full_path = os.path.abspath(relative_path)
 
     with open(full_path, "r") as f:
@@ -36,7 +36,10 @@ def construct_include(loader: Loader, node: yaml.Node) -> Any:
 
 
 def load_config_file(file_path):
-    """ Loads configuration file. If non-empty file exists reads data and returns it """
+    """
+    Loads configuration file. If non-empty file exists reads data and
+    returns it.
+    """
     with open(file_path, "r") as stream:
         logger.info(f"Loading file {file_path}")
         data = yaml.load(stream, Loader)

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class Reporter:
     def __init__(self, output_path=None, template=None):
-        """ Creates a Reporter instance object. """
+        """Creates a Reporter instance object."""
         self.output_path = output_path or "scanapi-report.html"
         self.template = template
 

--- a/scanapi/scan.py
+++ b/scanapi/scan.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def scan():
-    """ Caller function that tries to scans the file and write the report. """
+    """Caller function that tries to scans the file and write the report."""
     spec_path = settings["spec_path"]
 
     try:

--- a/scanapi/session.py
+++ b/scanapi/session.py
@@ -5,10 +5,10 @@ from scanapi.exit_code import ExitCode
 
 
 class Session:
-    """ Class that handles each scanapi session. """
+    """Class that handles each scanapi session."""
 
     def __init__(self):
-        """ Constructs a Session object. """
+        """Constructs a Session object."""
         self.successes = 0
         self.failures = 0
         self.errors = 0
@@ -17,11 +17,14 @@ class Session:
 
     @property
     def succeed(self):
-        """ Property decorated method that returns success (no errors or failures. """
+        """
+        Property decorated method that returns if there were no
+        no errors or failures.
+        """
         return self.errors == 0 and self.failures == 0
 
     def exit(self):
-        """ Handles the exiting of the Session """
+        """Handles the exiting of the Session."""
         if self.errors:
             sys.exit(ExitCode.TESTS_ERROR)
 
@@ -31,19 +34,19 @@ class Session:
         sys.exit(self.exit_code)
 
     def increment_successes(self):
-        """ Increments success count. """
+        """Increments success count."""
         self.successes += 1
 
     def increment_failures(self):
-        """ Increments failure count. """
+        """Increments failure count."""
         self.failures += 1
 
     def increment_errors(self):
-        """ Increments error count. """
+        """Increments error count."""
         self.errors += 1
 
     def elapsed_time(self):
-        """ Returns the delta of time since session object started. """
+        """Returns the delta of time since session object started."""
         return datetime.now() - self.started_at
 
 

--- a/scanapi/settings.py
+++ b/scanapi/settings.py
@@ -12,10 +12,13 @@ LOCAL_CONFIG_PATH = "./scanapi.conf"
 
 
 class Settings(dict):
-    """ Class for generating Settings dictionary. """
+    """Class for generating Settings dictionary."""
 
     def __init__(self):
-        """ Constructs a Settings object with dictionary keys spec_path, output_path and template. """
+        """
+        Constructs a Settings object with dictionary keys spec_path,
+        output_path and template.
+        """
         self["spec_path"] = "scanapi.yaml"
         self["output_path"] = None
         self["template"] = None
@@ -23,7 +26,7 @@ class Settings(dict):
         super(dict, self).__init__()
 
     def save_config_file_preferences(self, config_path=None):
-        """ Saves the Settings object config file preferences. """
+        """Saves the Settings object config file preferences."""
         if config_path:
             self["config_path"] = config_path
             self.update(**load_config_file(config_path))
@@ -35,14 +38,14 @@ class Settings(dict):
             self.update(**load_config_file(GLOBAL_CONFIG_PATH))
 
     def save_click_preferences(self, **preferences):
-        """ Saves all preference items to the Settings object. """
+        """Saves all preference items to the Settings object."""
         cleaned_preferences = {
             k: v for k, v in preferences.items() if v is not None
         }
         self.update(**cleaned_preferences)
 
     def save_preferences(self, **click_preferences):
-        """ Caller function that begins the saving of Setting preferences. """
+        """Caller function that begins the saving of Setting preferences."""
         config_path = (
             click_preferences["config_path"]
             if "config_path" in click_preferences
@@ -53,12 +56,12 @@ class Settings(dict):
 
     @property
     def has_global_config_file(self):
-        """ Checks if there is a global config file. """
+        """Checks if there is a global config file."""
         return os.path.isfile(GLOBAL_CONFIG_PATH)
 
     @property
     def has_local_config_file(self):
-        """ Checks if there is a local config file. """
+        """Checks if there is a local config file."""
         return os.path.isfile(LOCAL_CONFIG_PATH)
 
 

--- a/scanapi/template_render.py
+++ b/scanapi/template_render.py
@@ -3,7 +3,7 @@ from jinja2 import Environment, FileSystemLoader, PackageLoader
 
 
 def render(template_path, context, is_external=False):
-    """ Controller function that handles the Jinga2 rending of the template"""
+    """Controller function that handles the Jinja2 rending of the template."""
     loader = _loader(is_external)
     env = Environment(loader=loader, autoescape=True)
     env.filters["curlify"] = curlify2.to_curl
@@ -16,7 +16,10 @@ def render(template_path, context, is_external=False):
 
 
 def _loader(is_external):
-    """ Private function that either returns Jinga2 FileSystemLoader or the PackageLoader. """
+    """
+    Private function that either returns Jinja2 FileSystemLoader
+    or the PackageLoader.
+    """
     if is_external:
         return FileSystemLoader(searchpath="./")
 
@@ -24,7 +27,7 @@ def _loader(is_external):
 
 
 def render_body(request):
-    """ Render body according to its request content type """
+    """Render body according to its request content type."""
     content_type = request.headers.get("Content-Type")
     if content_type in ["application/json", "text/plain"]:
         return request.body.decode()

--- a/scanapi/test_status.py
+++ b/scanapi/test_status.py
@@ -1,5 +1,5 @@
 class TestStatus:
-    """ Class that holds test statuses - passed, failed or error. """
+    """Class that holds test statuses - passed, failed or error."""
 
     __test__ = False
     """

--- a/scanapi/utils.py
+++ b/scanapi/utils.py
@@ -23,20 +23,20 @@ def join_urls(first_url, second_url):
 
 
 def validate_keys(keys, available_keys, required_keys, scope):
-    """ Caller function that validates keys. """
+    """Caller function that validates keys."""
     _validate_allowed_keys(keys, available_keys, scope)
     _validate_required_keys(keys, required_keys, scope)
 
 
 def _validate_allowed_keys(keys, available_keys, scope):
-    """ Private function that checks validation of allowed keys. """
+    """Private function that checks validation of allowed keys."""
     for key in keys:
         if key not in available_keys:
             raise InvalidKeyError(key, scope, available_keys)
 
 
 def _validate_required_keys(keys, required_keys, scope):
-    """ Private function that checks validation of required keys. """
+    """Private function that checks validation of required keys."""
     if not set(required_keys) <= set(keys):
         missing_keys = set(required_keys) - set(keys)
         raise MissingMandatoryKeyError(missing_keys, scope)


### PR DESCRIPTION
## Description
Fix: No whitespaces allowed surrounding docstring text. We should avoid spaces at the beginning and at the end of a docstring.

There are 25 occurrences of this issue in the repository.

See all occurrences on DeepSource &rarr; [deepsource.io/gh/scanapi/scanapi/issue/FLK-D210/occurrences/](https://deepsource.io/gh/scanapi/scanapi/issue/FLK-D210/occurrences/)

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
Solve deepsource issues

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #412
