### PR TITLE
Fix: No use of self PYL-R0201

### DIFF
--- a/scanapi/tree/testing_node.py
+++ b/scanapi/tree/testing_node.py
@@ -57,7 +57,14 @@ class TestingNode:
             "error": error,
         }
 
-    def _process_result(self, status):
+    @staticmethod
+    def _process_result(status):
+        """Increment the number of session errors/failures/successes
+        depending on the test status.
+
+        Args:
+            status [string]: the status of the test: passed, failed or error.
+        """
         if status == TestStatus.ERROR:
             session.increment_errors()
             return


### PR DESCRIPTION
## Description
The method doesn&#x27;t use its bound instance. Decorate this method with `@staticmethod` decorator, so that Python does not have to instantiate a bound method for every instance of this class thereby saving memory and computation. Read more about staticmethods [here](https://docs.python.org/3/library/functions.html#staticmethod).

## Occurrences
There are 177 occurrences of this issue in the repository.

See all occurrences on DeepSource &rarr; [deepsource.io/gh/scanapi/scanapi/issue/PYL-R0201/occurrences/](https://deepsource.io/gh/scanapi/scanapi/issue/PYL-R0201/occurrences/)

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->

Fix deepsource issues

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->

Fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #414
