### PR TITLE
Rename master to main on ci

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,7 +1,7 @@
 name: Publish to Test PyPI
 on:
   push:
-    branches: [master]
+    branches: [main]
 jobs:
   build-n-publish-test-pypi:
     name: Test PyPI - Build and publish Python 🐍 distributions 📦

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Contributor Code of Conduct
 
 As one of the repositories under the `scanapi` GitHub organization, this repository follows the
-[ScanAPI Code of Conduct](https://github.com/scanapi/contributors/blob/master/CODE_OF_CONDUCT.md).
+[ScanAPI Code of Conduct](https://github.com/scanapi/contributors/blob/main/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://github.com/scanapi/design/raw/main/images/github-hero-dark.png)
 
 <p align="center">
-  <a href="https://app.circleci.com/pipelines/github/scanapi/scanapi?branch=master">
+  <a href="https://app.circleci.com/pipelines/github/scanapi/scanapi?branch=main">
     <img alt="CircleCI" src="https://img.shields.io/circleci/build/github/scanapi/scanapi">
   </a>
   <a href="https://codecov.io/gh/scanapi/scanapi">


### PR DESCRIPTION
## Description
Rename master to main on ci

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->

 https://github.com/github/renaming

## What type of change is this?
Refactor

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [ ] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [ ] Current PR does not significantly decrease the code coverage and docstring coverage.
- [ ] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
Closes #214
