### PR TITLE
Refactor on _validate method of EndpointNode

### DIFF
--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -98,17 +98,15 @@ class EndpointNode:
                 continue
 
     def _validate(self):
-        if self.is_root:
-            return validate_keys(
-                self.spec.keys(),
-                self.ALLOWED_KEYS,
-                self.ROOT_REQUIRED_KEYS,
-                ROOT_SCOPE,
-            )
-
-        validate_keys(
-            self.spec.keys(), self.ALLOWED_KEYS, self.REQUIRED_KEYS, self.SCOPE
+        """Private method that checks if the specification has any invalid key
+        or if there is any required key missing.
+        """
+        required_keys = (
+            self.ROOT_REQUIRED_KEYS if self.is_root else self.REQUIRED_KEYS
         )
+        scope = ROOT_SCOPE if self.is_root else self.SCOPE
+
+        validate_keys(self.spec.keys(), self.ALLOWED_KEYS, required_keys, scope)
 
     def _get_specs(self, field_name):
         values = self.spec.get(field_name, {})

--- a/scanapi/utils.py
+++ b/scanapi/utils.py
@@ -29,14 +29,30 @@ def validate_keys(keys, available_keys, required_keys, scope):
 
 
 def _validate_allowed_keys(keys, available_keys, scope):
-    """Private function that checks validation of allowed keys."""
+    """Private function that checks if the spec keys are allowed.
+
+    Args:
+        keys [list of strings]: the specification keys
+        available_keys [tuple of string]: the available keys for that scope
+        scope [string]: the scope of the current node: 'root', 'endpoint',
+        'request' or 'test'
+
+    """
     for key in keys:
         if key not in available_keys:
             raise InvalidKeyError(key, scope, available_keys)
 
 
 def _validate_required_keys(keys, required_keys, scope):
-    """Private function that checks validation of required keys."""
+    """Private function that checks if there is any required key missing.
+
+    Args:
+        keys [list of strings]: the specification keys
+        required_keys [tuple of string]: the required keys for that scope
+        scope [string]: the scope of the current node: 'root', 'endpoint',
+        'request' or 'test'
+
+    """
     if not set(required_keys) <= set(keys):
         missing_keys = set(required_keys) - set(keys)
         raise MissingMandatoryKeyError(missing_keys, scope)


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

Refactor on `_validate` method of EndpointNode. The method `validate_keys` has no return. `return` is used here to avoid calling `validate_keys` again.

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->

Avoid confusion.

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Refactor

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #423
