### PR TITLE
Fix: Docstrings converted to single-line

### DIFF
--- a/scanapi/__main__.py
+++ b/scanapi/__main__.py
@@ -16,9 +16,7 @@ dist = get_distribution("scanapi")
 @click.group()
 @click.version_option(version=dist.version)
 def main():
-    """
-    Automated Testing and Documentation for your REST API.
-    """
+    """Automated Testing and Documentation for your REST API."""
     pass
 
 

--- a/scanapi/config_loader.py
+++ b/scanapi/config_loader.py
@@ -1,4 +1,4 @@
-"""Code based on solution https://gist.github.com/joshbode/569627ced3076931b02f"""
+"""Code Reference https://gist.github.com/joshbode/569627ced3076931b02f"""
 
 import logging
 import os

--- a/scanapi/config_loader.py
+++ b/scanapi/config_loader.py
@@ -1,6 +1,4 @@
-"""
-Code based on solution https://gist.github.com/joshbode/569627ced3076931b02f
-"""
+"""Code based on solution https://gist.github.com/joshbode/569627ced3076931b02f"""
 
 import logging
 import os

--- a/scanapi/exit_code.py
+++ b/scanapi/exit_code.py
@@ -7,9 +7,7 @@ import enum
 
 
 class ExitCode(enum.IntEnum):
-    """
-    Encodes the valid exit codes by ScanAPI.
-    """
+    """Encodes the valid exit codes by ScanAPI."""
 
     #: tests passed
     OK = 0


### PR DESCRIPTION
## Description
These docstrings fits in a single line according to PEP8.

Reference: https://deepsource.io/gh/scanapi/scanapi/issue/FLK-D200/occurrences

## Motivation behind this PR?
Solve DeepSource issues.

## What type of change is this?
Fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #411

