### PR TITLE
Fix: Break lines in column to prevent overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Header table gets broken. [#432](https://github.com/scanapi/scanapi/pull/432)
 
 ## [2.5.0] - 2021-07-23
 ### Added

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -159,6 +159,10 @@
             margin: auto;
         }
 
+        .wordbreak {
+            word-break: break-all;
+        }
+
         @media only screen and (max-width: 767px) {
             .wrapper {
                 width: auto;
@@ -462,7 +466,7 @@
                                 <td>
                                     {{ key }}
                                 </td>
-                                <td>
+                                <td class="wordbreak">
                                     {{value}}
                                 </td>
                             </tr>
@@ -494,7 +498,7 @@
                                 <td>
                                     status code
                                 </td>
-                                <td>
+                                <td class="wordbreak">
                                     {{ response.status_code }}
                                 </td>
                             </tr>
@@ -502,7 +506,7 @@
                                 <td>
                                     response time
                                 </td>
-                                <td>
+                                <td class="wordbreak">
                                     {{ response.elapsed.total_seconds() }} s
                                 </td>
                             </tr>
@@ -510,7 +514,7 @@
                                 <td>
                                     redirect
                                 </td>
-                                <td>
+                                <td class="wordbreak">
                                     {{ response.is_redirect }}
                                 </td>
                             </tr>
@@ -537,7 +541,7 @@
                                     <td>
                                         {{ key }}
                                     </td>
-                                    <td>
+                                    <td class="wordbreak">
                                         {{value}}
                                     </td>
                                 </tr>


### PR DESCRIPTION
- Use break-all css in the right columns of the table to prevent overflow,
- Update the Changelog

## Description
Fix for issue https://github.com/scanapi/scanapi/issues/409

## Motivation behind this PR?
in some html tables when there is long data, the data gets out of the table

## What type of change is this?
Bug Fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [X]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [ ] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [X] Current PR does not significantly decrease the code coverage and docstring coverage.
- [ ] My code follows the style guidelines of this project.
- [X] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes 409
