### PR TITLE
make change-version: create a readable PEP440-compatible dev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-timestamp = `date -u --rfc-3339=seconds | tr -d : | tr " -" .. | cut -f1 -d+`
+timestamp = `date -u +'%Y.%m.%d.%H%M%S'`
 
 test:
 	@pytest --cov=./scanapi --cov-report=xml
@@ -12,7 +12,7 @@ flake8:
 check: black flake8
 
 change-version:
-	@poetry version `poetry version -s | sed -re 's/\.dev.+//'`.dev$(timestamp)
+	@poetry version `poetry version -s | cut -f-3 -d.`.dev$(timestamp)
 
 format:
 	@black -l 80 . --exclude=.venv

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-timestamp = `date +%s`
-
+timestamp = `date -u --rfc-3339=seconds | tr -d : | tr " -" .. | cut -f1 -d+`
 
 test:
 	@pytest --cov=./scanapi --cov-report=xml
@@ -13,7 +12,7 @@ flake8:
 check: black flake8
 
 change-version:
-	@poetry version 2.1.0-$(timestamp)
+	@poetry version `poetry version -s | sed -re 's/\.dev.+//'`.dev$(timestamp)
 
 format:
 	@black -l 80 . --exclude=.venv
@@ -31,4 +30,4 @@ run:
 bandit:
 	@bandit -r scanapi
 
-.PHONY: test format check install sh run
+.PHONY: test black flake8 check change-version format install sh run bandit


### PR DESCRIPTION
Make "make change-version" useful again by keeping the current release version, and adding a human readable and PEP440 compliant timestamp to it.

Also fixed `PHONY`.

Closes https://github.com/scanapi/scanapi/issues/464