### PR TITLE
Updated doc strung to fit on one line with quotes

### DIFF
--- a/scanapi/exit_code.py
+++ b/scanapi/exit_code.py
@@ -1,7 +1,5 @@
-"""
-Code based on solution https://github.com/pytest-dev/pytest/blob/\
-83891d9022076375cede03bfd8c932d450e6fcf8/src/_pytest/config/__init__.py#L67
-"""
+"""Code based on solution: https://github.com/pytest-dev/pytest/blob/\
+83891d9022076375cede03bfd8c932d450e6fcf8/src/_pytest/config/__init__.py#L67"""
 
 import enum
 


### PR DESCRIPTION
## Description
Updated doc strung to fit on one line with quotes

## Motivation behind this PR?
Fixes (FLK-D200) One-line docstring should fit on one line with quotes #454

## What type of change is this?
Bug Fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [ ]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [ ] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [ ] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
Closes https://github.com/scanapi/scanapi/issues/454
