### PR TITLE
Fix typing in `config_loader`

### DIFF
--- a/scanapi/errors.py
+++ b/scanapi/errors.py
@@ -1,5 +1,5 @@
 class MalformedSpecError(Exception):
-    pass
+    """Base class for API spec errors."""
 
 
 class HTTPMethodNotAllowedError(MalformedSpecError):
@@ -55,3 +55,7 @@ class EmptyConfigFileError(Exception):
     def __init__(self, file_path, *args):
         message = f"File '{file_path}' is empty."
         super(EmptyConfigFileError, self).__init__(message, *args)
+
+
+class BadConfigIncludeError(Exception):
+    """Raised when the value of the !include yaml tag is not a scalar."""

--- a/tests/data/api_non_scalar_include.yaml
+++ b/tests/data/api_non_scalar_include.yaml
@@ -1,0 +1,4 @@
+endpoints:
+  - name: scanapi-demo
+    path: ${BASE_URL}
+    requests: !include {a: "b"}

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,7 +1,7 @@
 from pytest import mark, raises
 
 from scanapi.config_loader import load_config_file
-from scanapi.errors import EmptyConfigFileError
+from scanapi.errors import BadConfigIncludeError, EmptyConfigFileError
 
 
 @mark.describe("config loader")
@@ -64,3 +64,11 @@ class TestLoadConfigFile:
 
         assert "[Errno 2] No such file or directory: " in str(excinfo.value)
         assert "tests/data/invalid_path/include.yaml'" in str(excinfo.value)
+
+    @mark.context("include value is not a scalar")
+    @mark.it("should raise an exception")
+    def test_should_raise_exception_4(self):
+        with raises(BadConfigIncludeError) as excinfo:
+            load_config_file("tests/data/api_non_scalar_include.yaml")
+
+        assert "Include tag value is not a scalar" in str(excinfo.value)


### PR DESCRIPTION
## Description
The typing already present in the `scanapi.config_loader` module raises `mypy` errors.  For #456 to work these erros need to be fixed.

The `mypy` errors were actually helpful to identify a potential source of errors in parsing of config files, which has also been fixed.

## Motivation behind this PR?
Mypy will presumable be part of the CI, so all type annotations have to be correct.

## How to test
Since #456 has not been merged yet one needs to either manually install `mypy`, or rebase this branch onto the branch from #456:
```
git rebase --onto=add-mypy main
```
then 
```
make mypy
```
undo rebase
```
git rebase --onto=main add-mypy
git reset origin/fix/config-loader-typing
```

## What type of change is this?
Fix wrong type annotation.

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
Closes #457 
