### PR TITLE
replace 'vars' with 'spec_vars' (close #436)

### DIFF
--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -18,14 +18,14 @@ class CodeEvaluator:
     )  # ${{<python_code>}}
 
     @classmethod
-    def evaluate(cls, sequence, vars, is_a_test_case=False):
+    def evaluate(cls, sequence, spec_vars, is_a_test_case=False):
         match = cls.python_code_pattern.search(str(sequence))
 
         if not match:
             return sequence
 
         code = match.group("python_code")
-        response = vars.get("response")
+        response = spec_vars.get("response")
 
         try:
             if is_a_test_case:

--- a/scanapi/evaluators/spec_evaluator.py
+++ b/scanapi/evaluators/spec_evaluator.py
@@ -8,10 +8,10 @@ logger = logging.getLogger(__name__)
 
 
 class SpecEvaluator:
-    def __init__(self, endpoint, vars_, extras=None, filter_responses=True):
+    def __init__(self, endpoint, spec_vars, extras=None, filter_responses=True):
         self.endpoint = endpoint
         self.registry = {}
-        self.update(vars_, extras=extras, filter_responses=filter_responses)
+        self.update(spec_vars, extras=extras, filter_responses=filter_responses)
 
     def evaluate(self, element):
         return evaluate(element, self)
@@ -19,14 +19,16 @@ class SpecEvaluator:
     def evaluate_assertion(self, element):
         return _evaluate_str(element, self, is_a_test_case=True)
 
-    def update(self, vars, extras=None, filter_responses=False):
+    def update(self, spec_vars, extras=None, filter_responses=False):
         if extras is None:
             extras = {}
 
         if filter_responses:
-            vars = self.filter_response_var(vars)
+            spec_vars = self.filter_response_var(spec_vars)
 
-        values = {key: evaluate(value, extras) for key, value in vars.items()}
+        values = {
+            key: evaluate(value, extras) for key, value in spec_vars.items()
+        }
         self.registry.update(extras)
         self.registry.update(values)
 
@@ -43,8 +45,8 @@ class SpecEvaluator:
         if key in self:
             return self.registry[key]
 
-        if key in self.endpoint.parent.vars:
-            return self.endpoint.parent.vars[key]
+        if key in self.endpoint.parent.spec_vars:
+            return self.endpoint.parent.spec_vars[key]
 
         raise KeyError(key)
 
@@ -66,32 +68,35 @@ class SpecEvaluator:
         return self.registry.keys()
 
     @classmethod
-    def filter_response_var(cls, vars_):
-        """Returns a dictionary without vars that evaluate response.
+    def filter_response_var(cls, spec_vars):
+        """Returns a copy pf ``spec_vars`` without 'response' references.
+
+        Any items with a ``response.*`` reference in their value are left out.
+
         Returns:
             [dict]: filtered dictionary.
 
         """
         pattern = re.compile(r"(?:(\s*response\.\w+))")
-        return {k: v for k, v in vars_.items() if not pattern.search(v)}
+        return {k: v for k, v in spec_vars.items() if not pattern.search(v)}
 
 
 @singledispatch
-def evaluate(expression, vars):
+def evaluate(expression, spec_vars):
     return expression
 
 
 @evaluate.register(str)
-def _evaluate_str(element, vars, is_a_test_case=False):
-    return StringEvaluator.evaluate(element, vars, is_a_test_case)
+def _evaluate_str(element, spec_vars, is_a_test_case=False):
+    return StringEvaluator.evaluate(element, spec_vars, is_a_test_case)
 
 
 @evaluate.register(dict)
-def _evaluate_dict(element, vars):
-    return {key: evaluate(value, vars) for key, value in element.items()}
+def _evaluate_dict(element, spec_vars):
+    return {key: evaluate(value, spec_vars) for key, value in element.items()}
 
 
 @evaluate.register(list)
 @evaluate.register(tuple)
-def _evaluate_collection(elements, vars):
-    return [evaluate(item, vars) for item in elements]
+def _evaluate_collection(elements, spec_vars):
+    return [evaluate(item, spec_vars) for item in elements]

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -14,11 +14,11 @@ class StringEvaluator:
     )  # ${<variable>}
 
     @classmethod
-    def evaluate(cls, sequence, vars, is_a_test_case=False):
+    def evaluate(cls, sequence, spec_vars, is_a_test_case=False):
         sequence = cls._evaluate_env_var(sequence)
-        sequence = cls._evaluate_custom_var(sequence, vars)
+        sequence = cls._evaluate_custom_var(sequence, spec_vars)
 
-        return CodeEvaluator.evaluate(sequence, vars, is_a_test_case)
+        return CodeEvaluator.evaluate(sequence, spec_vars, is_a_test_case)
 
     @classmethod
     def _evaluate_env_var(cls, sequence):
@@ -45,7 +45,7 @@ class StringEvaluator:
         return sequence
 
     @classmethod
-    def _evaluate_custom_var(cls, sequence, vars):
+    def _evaluate_custom_var(cls, sequence, spec_vars):
         matches = cls.variable_pattern.finditer(sequence)
 
         if not matches:
@@ -57,10 +57,10 @@ class StringEvaluator:
             if variable_name.isupper():
                 continue
 
-            if not vars.get(variable_name):
+            if not spec_vars.get(variable_name):
                 continue
 
-            variable_value = vars.get(variable_name)
+            variable_value = spec_vars.get(variable_name)
 
             sequence = cls.replace_var_with_value(
                 sequence, match.group(), variable_value

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -41,7 +41,7 @@ class EndpointNode:
         self.parent = parent
         self.child_nodes = []
         self.__build()
-        self.vars = SpecEvaluator(self, spec.get(VARS_KEY, {}))
+        self.spec_vars = SpecEvaluator(self, spec.get(VARS_KEY, {}))
 
     def __build(self):
         self._validate()
@@ -68,7 +68,7 @@ class EndpointNode:
         path = str(self.spec.get(PATH_KEY, "")).strip()
         url = join_urls(self.parent.path, path) if self.parent else path
 
-        return self.vars.evaluate(url)
+        return self.spec_vars.evaluate(url)
 
     @property
     def headers(self):

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -77,21 +77,21 @@ class RequestNode:
         path = str(self.spec.get(PATH_KEY, ""))
         full_url = join_urls(base_path, path)
 
-        return self.endpoint.vars.evaluate(full_url)
+        return self.endpoint.spec_vars.evaluate(full_url)
 
     @property
     def headers(self):
         endpoint_headers = self.endpoint.headers
         headers = self.spec.get(HEADERS_KEY, {})
 
-        return self.endpoint.vars.evaluate({**endpoint_headers, **headers})
+        return self.endpoint.spec_vars.evaluate({**endpoint_headers, **headers})
 
     @property
     def params(self):
         endpoint_params = self.endpoint.params
         params = self.spec.get(PARAMS_KEY, {})
 
-        return self.endpoint.vars.evaluate({**endpoint_params, **params})
+        return self.endpoint.spec_vars.evaluate({**endpoint_params, **params})
 
     @property
     def delay(self):
@@ -102,7 +102,7 @@ class RequestNode:
     def body(self):
         body = self.spec.get(BODY_KEY)
 
-        return self.endpoint.vars.evaluate(body)
+        return self.endpoint.spec_vars.evaluate(body)
 
     @property
     def tests(self):
@@ -128,9 +128,9 @@ class RequestNode:
         url = self.full_url_path
         logger.info("Making request %s %s", method, url)
 
-        self.endpoint.vars.update(
+        self.endpoint.spec_vars.update(
             self.spec.get(VARS_KEY, {}),
-            extras=dict(self.endpoint.vars),
+            extras=dict(self.endpoint.spec_vars),
             filter_responses=True,
         )
 
@@ -144,17 +144,17 @@ class RequestNode:
             allow_redirects=False,
         )
 
-        extras = dict(self.endpoint.vars)
+        extras = dict(self.endpoint.spec_vars)
         extras["response"] = response
 
-        self.endpoint.vars.update(
+        self.endpoint.spec_vars.update(
             self.spec.get(VARS_KEY, {}), extras=extras,
         )
 
         tests_results = self._run_tests()
         hide_sensitive_info(response)
 
-        del self.endpoint.vars["response"]
+        del self.endpoint.spec_vars["response"]
 
         return {
             "response": response,

--- a/scanapi/tree/testing_node.py
+++ b/scanapi/tree/testing_node.py
@@ -36,7 +36,10 @@ class TestingNode:
 
     def run(self):
         try:
-            passed, failure = self.request.endpoint.vars.evaluate_assertion(
+            (
+                passed,
+                failure,
+            ) = self.request.endpoint.spec_vars.evaluate_assertion(
                 self.assertion
             )
 

--- a/tests/unit/evaluators/test_code_evaluator.py
+++ b/tests/unit/evaluators/test_code_evaluator.py
@@ -70,12 +70,12 @@ class TestEvaluate:
     @mark.context("when it is a test case")
     @mark.context("when code breaks")
     @mark.it("should raises invalid python code error")
-    @mark.parametrize("sequence, vars_, is_a_test_case", test_data)
+    @mark.parametrize("sequence, spec_vars, is_a_test_case", test_data)
     def test_should_raises_invalid_python_code_error(
-        self, sequence, vars_, is_a_test_case
+        self, sequence, spec_vars, is_a_test_case
     ):
         with raises(InvalidPythonCodeError) as excinfo:
-            CodeEvaluator.evaluate(sequence, vars_, is_a_test_case)
+            CodeEvaluator.evaluate(sequence, spec_vars, is_a_test_case)
 
         assert isinstance(excinfo.value, InvalidPythonCodeError)
 

--- a/tests/unit/evaluators/test_spec_evaluator.py
+++ b/tests/unit/evaluators/test_spec_evaluator.py
@@ -77,8 +77,8 @@ class TestFilterResponseVar:
     def test_should_return_dictionary_without_response_var(
         self, spec_evaluator
     ):
-        vars_ = {"var_1": "${{response.json()['key']}}", "var_2": "foo"}
-        assert spec_evaluator.filter_response_var(vars_) == {"var_2": "foo"}
+        spec_vars = {"var_1": "${{response.json()['key']}}", "var_2": "foo"}
+        assert spec_evaluator.filter_response_var(spec_vars) == {"var_2": "foo"}
 
 
 @mark.describe("spec evaluator")

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -135,12 +135,15 @@ class TestEvaluateCustomVar:
     @mark.it("should return sequence with evaluated custom var")
     @mark.parametrize("sequence, expected", test_data)
     def test_should_return_sequence_3(self, sequence, expected):
-        vars = {
+        spec_vars = {
             "user_id": "10",
             "apiKey": "abc123",
             "api-token": "xwo",
         }
-        assert StringEvaluator._evaluate_custom_var(sequence, vars) == expected
+        assert (
+            StringEvaluator._evaluate_custom_var(sequence, spec_vars)
+            == expected
+        )
 
 
 @mark.describe("string evaluator")

--- a/tests/unit/tree/endpoint_node/test_validate.py
+++ b/tests/unit/tree/endpoint_node/test_validate.py
@@ -1,6 +1,6 @@
 from pytest import fixture, mark
 
-from scanapi.tree import EndpointNode
+from scanapi.tree import EndpointNode, tree_keys
 
 
 @mark.describe("endpoint node")
@@ -32,7 +32,7 @@ class TestValidate:
                 "path",
                 "requests",
                 "delay",
-                "vars",
+                tree_keys.VARS_KEY,
             ),
             ("name",),
             "endpoint",

--- a/tests/unit/tree/request_node/test_validate.py
+++ b/tests/unit/tree/request_node/test_validate.py
@@ -1,6 +1,6 @@
 from pytest import fixture, mark
 
-from scanapi.tree import EndpointNode, RequestNode
+from scanapi.tree import EndpointNode, RequestNode, tree_keys
 
 
 @mark.describe("request node")
@@ -33,7 +33,7 @@ class TestValidate:
                 "params",
                 "path",
                 "tests",
-                "vars",
+                tree_keys.VARS_KEY,
                 "delay",
                 "retry",
             ),


### PR DESCRIPTION
Implements #436 

Since vars() is a builtin keyword. It's generally an anti-pattern to redefine builtin functions.