### PR TITLE
Invalid version in poetry build (#467)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-timestamp = `date +%s`
-
+timestamp = `date -u +'%Y%m%d%H%M%S'`
 
 test:
 	@pytest --cov=./scanapi --cov-report=xml
@@ -13,7 +12,7 @@ flake8:
 check: black flake8
 
 change-version:
-	@poetry version 2.1.0-$(timestamp)
+	@poetry version `poetry version -s | cut -f-3 -d.`.dev$(timestamp)
 
 format:
 	@black -l 80 . --exclude=.venv
@@ -31,4 +30,4 @@ run:
 bandit:
 	@bandit -r scanapi
 
-.PHONY: test format check install sh run
+.PHONY: test black flake8 check change-version format install sh run bandit


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
format version identifiers according to PEP 440, without dots after dev numbers. https://www.python.org/dev/peps/pep-0440/#public-version-identifiers

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
Poetry throw invalid version during build.

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [ ] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [ ] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #467
