### PR TITLE
automation: add autoenv '.env' activator for poetry venv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# autoenv activation (like "poetry shell", but better)
+if type -t poetry >/dev/null; then
+    . $(poetry env info -p | head -n1)/bin/activate
+    echo "*** Activated $(basename $(readlink -f .))" $(poetry version -s)
+fi


### PR DESCRIPTION
As discussed on EP matrix channel, activate the venv on (auto-)cd into the project workdir.

@camilamaia please check if this works on MacOS (the readlink -f might fail).