### PR TITLE
Remove if not matches: from StringEvaluator

### DIFF
--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -24,9 +24,6 @@ class StringEvaluator:
     def _evaluate_env_var(cls, sequence):
         matches = cls.variable_pattern.finditer(sequence)
 
-        if not matches:
-            return sequence
-
         for match in matches:
             variable_name = match.group("variable")
 
@@ -47,9 +44,6 @@ class StringEvaluator:
     @classmethod
     def _evaluate_custom_var(cls, sequence, spec_vars):
         matches = cls.variable_pattern.finditer(sequence)
-
-        if not matches:
-            return sequence
 
         for match in matches:
             variable_name = match.group("variable")


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

Removed unuseful lines. `matches` variable is a callable_iterator object, so it will never be null. We can remove the check since when there is no match with the pattern, it will not go into the loop.


## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->


## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Refactor

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working on something that does not need to be done. -->
Closes #488
