### PR TITLE
add unit test for _repr__ method for EndpointNode class  #484

### DIFF
--- a/tests/unit/tree/endpoint_node/test_repr.py
+++ b/tests/unit/tree/endpoint_node/test_repr.py
@@ -1,0 +1,21 @@
+from pytest import mark
+
+from scanapi.tree import EndpointNode
+
+
+@mark.describe("endpoint node")
+@mark.describe("__repr__")
+class TestName:
+    @mark.context("when parent spec has no name defined")
+    @mark.it("should return <EndpointNode child-node>")
+    def test_when_parent_has_no_name(self):
+        node = EndpointNode({"name": "child-node"}, parent=EndpointNode({}))
+        assert repr(node) == "<EndpointNode child-node>"
+
+    @mark.context("when parent spec has a name defined")
+    @mark.it("should return <EndpointNode root::child-node>")
+    def test_when_parent_has_name(self):
+        parent = EndpointNode({"name": "root"})
+        node = EndpointNode({"name": "child-node"}, parent=parent)
+        assert repr(node) == "<EndpointNode root::child-node>"
+        

--- a/tests/unit/tree/endpoint_node/test_repr.py
+++ b/tests/unit/tree/endpoint_node/test_repr.py
@@ -5,7 +5,7 @@ from scanapi.tree import EndpointNode
 
 @mark.describe("endpoint node")
 @mark.describe("__repr__")
-class TestName:
+class TestRepr:
     @mark.context("when parent spec has no name defined")
     @mark.it("should return <EndpointNode child-node>")
     def test_when_parent_has_no_name(self):
@@ -18,4 +18,3 @@ class TestName:
         parent = EndpointNode({"name": "root"})
         node = EndpointNode({"name": "child-node"}, parent=parent)
         assert repr(node) == "<EndpointNode root::child-node>"
-        


### PR DESCRIPTION
## Description
This pull request add a unit test for __repr__ for the Endpoint class inside test_repr.py

## Motivation behind this PR?
#484 

## What type of change is this?
Unit test

## Checklist


- [x] I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).

## Issue
Closes #484 
