### PR TITLE
test: add unit test for method '__repr__' of RequestNode class

### DIFF
--- a/tests/unit/tree/request_node/test_repr.py
+++ b/tests/unit/tree/request_node/test_repr.py
@@ -1,0 +1,53 @@
+from pytest import mark
+
+from scanapi.tree import EndpointNode, RequestNode
+
+
+@mark.describe("request node")
+@mark.describe("__repr__")
+class TestRepr:
+    @mark.context("when path is not defined")
+    @mark.it("should return <RequestNode >")
+    def test_when_path_is_not_defined(self):
+        endpoint = EndpointNode({"name": "foo", "requests": [{}]})
+        request = RequestNode(spec={"name": "bar"}, endpoint=endpoint)
+        assert repr(request) == "<RequestNode >"
+
+    @mark.context("when endpoint node path is defined")
+    @mark.it("should return <RequestNode endpoint_path>")
+    def test_when_endpoint_path_is_defined(self):
+        base_path = "http://foo.com/api"
+        parent = EndpointNode(
+            {"path": base_path, "name": "parent-node", "requests": []}
+        )
+        endpoint = EndpointNode(
+            {"path": "/foo", "name": "node", "requests": []}, parent=parent
+        )
+
+        request = RequestNode(spec={"name": "bar"}, endpoint=endpoint)
+        assert repr(request) == "<RequestNode http://foo.com/api/foo>"
+
+    @mark.context("when request node path is defined")
+    @mark.it("should return <RequestNode request_path>")
+    def test_when_request_node_path_is_defined(self):
+        endpoint = EndpointNode({"name": "foo", "requests": [{}]})
+        request = RequestNode(
+            spec={"name": "bar", "path": "/bar/"}, endpoint=endpoint
+        )
+        assert repr(request) == "<RequestNode /bar/>"
+
+    @mark.context("when both request and endpoint paths are defined")
+    @mark.it("should return <RequestNode endpoint_path/request_path>")
+    def test_when_request_and_endpoint_paths_are_defined(self):
+        base_path = "http://foo.com/api"
+        parent = EndpointNode(
+            {"path": base_path, "name": "parent-node", "requests": []}
+        )
+        endpoint = EndpointNode(
+            {"path": "/foo", "name": "node", "requests": []}, parent=parent
+        )
+
+        request = RequestNode(
+            spec={"name": "bar", "path": "/bar/"}, endpoint=endpoint
+        )
+        assert repr(request) == "<RequestNode http://foo.com/api/foo/bar/>"


### PR DESCRIPTION
## Description
This pull request adds unit tests for the method `__repr__` of RequestNode class

## Motivation behind this PR?
Add unit tests and closes issue #485 

## What type of change is this?
Unit tests

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [ ] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #485
