### PR TITLE
Release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.0] - 2021-08-13
 ### Changed
 - Summary tests location to the top of the report [#479](https://github.com/scanapi/scanapi/pull/479)
 
@@ -224,7 +226,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.6.0...HEAD
+[2.6.0]: https://github.com/camilamaia/scanapi/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/camilamaia/scanapi/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/camilamaia/scanapi/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/camilamaia/scanapi/compare/v2.2.0...v2.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN pip install scanapi==2.5.0
+RUN pip install scanapi==2.6.0
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.5.0"
+version = "2.6.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Changed
- Summary tests location to the top of the report [#479](https://github.com/scanapi/scanapi/pull/479)

### Fixed
- Header table gets broken. [#432](https://github.com/scanapi/scanapi/pull/432)