### PR TITLE
Add a --browse option in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Summary tests location to the top of the report [#479](https://github.com/scanapi/scanapi/pull/479)
+- Add the flag `--browser` or `-b` for short [#465]
 
 ### Fixed
 - Header table gets broken. [#432](https://github.com/scanapi/scanapi/pull/432)

--- a/scanapi/__main__.py
+++ b/scanapi/__main__.py
@@ -37,6 +37,13 @@ def main():
     help="Run ScanAPI without generating report.",
 )
 @click.option(
+    "-b",
+    "--browser",
+    "open_browser",
+    is_flag=True,
+    help="Open the results file using a browser",
+)
+@click.option(
     "-c",
     "--config-path",
     "config_path",
@@ -58,7 +65,15 @@ def main():
     default="INFO",
     help="Set the debug logging level for the program.",
 )
-def run(spec_path, output_path, no_report, config_path, template, log_level):
+def run(
+    spec_path,
+    output_path,
+    no_report,
+    config_path,
+    template,
+    log_level,
+    open_browser,
+):
     """
     Automated Testing and Documentation for your REST API.
     SPEC_PATH argument is the API specification file path.
@@ -72,6 +87,7 @@ def run(spec_path, output_path, no_report, config_path, template, log_level):
         "no_report": no_report,
         "config_path": config_path,
         "template": template,
+        "open_browser": open_browser,
     }
 
     try:

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import datetime
 import logging
+import webbrowser
 from os.path import abspath
 
 from pkg_resources import get_distribution
@@ -51,6 +52,10 @@ class Reporter:
 
         logger.info("\nThe documentation was generated successfully.")
         logger.info(f"It is available at {abspath(self.output_path)}")
+
+    def open_report_in_browser(self):
+        """Open the results file on a browser"""
+        webbrowser.open(self.output_path)
 
     @staticmethod
     def write_without_generating_report(results):

--- a/scanapi/scan.py
+++ b/scanapi/scan.py
@@ -22,6 +22,7 @@ def scan():
     """Caller function that tries to scans the file and write the report."""
     spec_path = settings["spec_path"]
     no_report = settings["no_report"]
+    open_browser = settings["open_browser"]
 
     try:
         api_spec = load_config_file(spec_path)
@@ -54,6 +55,8 @@ def scan():
     else:
         try:
             write_report(results)
+            if open_browser:
+                open_report_in_browser()
         except (BadConfigurationError, InvalidPythonCodeError) as e:
             logger.error(e)
             raise SystemExit(ExitCode.USAGE_ERROR)
@@ -67,6 +70,12 @@ def write_report(results):
     """
     reporter = Reporter(settings["output_path"], settings["template"])
     reporter.write(results)
+
+
+def open_report_in_browser():
+    """Open the results file on a browser"""
+    reporter = Reporter(settings["output_path"], settings["template"])
+    reporter.open_report_in_browser()
 
 
 def write_without_generating_report(results):

--- a/scanapi/settings.py
+++ b/scanapi/settings.py
@@ -23,8 +23,9 @@ class Settings(dict):
         self["output_path"] = None
         self["template"] = None
         self["no_report"] = False
+        self["open_browser"] = False
 
-        super(dict, self).__init__()
+        super().__init__()
 
     def save_config_file_preferences(self, config_path=None):
         """Saves the Settings object config file preferences."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -31,6 +31,7 @@ class TestRun:
                 "spec_path": None,
                 "output_path": "my_output.html",
                 "no_report": False,
+                "open_browser": False,
                 "config_path": None,
                 "template": None,
             }

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -7,7 +7,7 @@ import yaml
 from pytest import fixture, mark, raises
 
 from scanapi.errors import EmptyConfigFileError, InvalidKeyError
-from scanapi.scan import scan, write_report
+from scanapi.scan import open_report_in_browser, scan, write_report
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +44,11 @@ class TestScan:
     def test_should_log_error(self, mocker, caplog):
         mocker.patch(
             "scanapi.scan.settings",
-            {"spec_path": "invalid_path/scanapi.yaml", "no_report": False},
+            {
+                "spec_path": "invalid_path/scanapi.yaml",
+                "no_report": False,
+                "open_browser": False,
+            },
         )
         mocker.patch(
             "scanapi.scan.load_config_file", side_effect=file_not_found
@@ -137,6 +141,44 @@ class TestScan:
         assert mock_endpoint_run.called
         mock_write_report.assert_called_once_with([response])
 
+    @mark.context(
+        "when the api spec is ok and the is configured to open the results"
+    )
+    @mark.it("should call reporter write_report and open_report_in_browser")
+    def test_should_call_reporter_and_open_results(self, mocker, response):
+        mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
+        mock_load_config_file.return_value = {"endpoints": []}
+        mock_endpoint_init = mocker.patch("scanapi.scan.EndpointNode.__init__")
+        mock_endpoint_init.return_value = None
+        mock_endpoint_run = mocker.patch("scanapi.scan.EndpointNode.run")
+        mock_endpoint_run.return_value = [response]
+        mock_write_report = mocker.patch("scanapi.scan.write_report")
+        mock_open_report_in_browser = mocker.patch(
+            "scanapi.scan.open_report_in_browser"
+        )
+        mocker.patch(
+            "scanapi.scan.settings",
+            {
+                "spec_path": None,
+                "output_path": "out/my-report.md",
+                "no_report": False,
+                "open_browser": True,
+                "reporter": "markdown",
+                "template": "my-template.jinja",
+            },
+        )
+
+        with raises(SystemExit) as excinfo:
+            scan()
+
+        assert excinfo.type == SystemExit
+        assert excinfo.value.code == 0
+
+        mock_endpoint_init.assert_called_once_with({"endpoints": []})
+        assert mock_endpoint_run.called
+        mock_write_report.assert_called_once_with([response])
+        mock_open_report_in_browser.assert_called_once()
+
 
 @mark.describe("scan")
 @mark.describe("write_report")
@@ -162,3 +204,30 @@ class TestWriteReport:
             "out/my-report.md", "my-template.jinja"
         )
         mock_write.assert_called_once_with([response])
+
+
+@mark.describe("scan")
+@mark.describe("open_report_in_browser")
+class TestOpenReport:
+    @mark.it("should call open browser")
+    def test_should_call_wr(self, mocker, response):
+        mock_open = mocker.patch("scanapi.scan.Reporter.open_report_in_browser")
+        mock_reporter_init = mocker.patch("scanapi.scan.Reporter.__init__")
+        mock_reporter_init.return_value = None
+        mocker.patch(
+            "scanapi.scan.settings",
+            {
+                "output_path": "out/my-report.md",
+                "no_report": False,
+                "reporter": "markdown",
+                "template": "my-template.jinja",
+            },
+        )
+
+        open_report_in_browser()
+
+        mock_reporter_init.assert_called_once_with(
+            "out/my-report.md", "my-template.jinja"
+        )
+
+        mock_open.assert_called_once()

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -152,6 +152,7 @@ class TestSaveClickPreferences:
             "output_path": "path/output-path",
             "template": None,
             "no_report": False,
+            "open_browser": False,
             "config_path": "path/config-path",
         }
 


### PR DESCRIPTION
## Description
I added a new option to open the report result on a browser.

## Motivation behind this PR?
Closes #465

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
It is a new feature

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [ ] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #465
