### PR TITLE
Upgrade types-PyYAML from ^5.4.3 to ^5.4.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -943,7 +943,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2,<4.0.0"
-content-hash = "75b70e5d257e3e40fc434186daccaada6bf326858febb68aa65eead082aa950a"
+content-hash = "34965cb248f0122c1bd97e5a296ff4b93a486964cd180376f88c580c148d70fb"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ pytest-it = "^0.1.4"
 flake8 = "3.8.4"
 mypy = "^0.910"
 types-requests = "^2.25.1"
-types-PyYAML = "^5.4.3"
+types-PyYAML = "^5.4.6"
 types-setuptools = "^57.0.0"
 gitlint = "0.15.1"
 

--- a/scanapi/config_loader.py
+++ b/scanapi/config_loader.py
@@ -53,7 +53,4 @@ def load_config_file(file_path):
         return data
 
 
-# Ignore parameter types due to wrong annotations in `typeshed`. Fix submitted
-# in https://github.com/python/typeshed/pull/5828
-# Can remove "type: ignore" once `types-PyYAML` has been updated.
 yaml.add_constructor("!include", construct_include, Loader)


### PR DESCRIPTION
## Description
The minimal version for `types-PyYAML` in `pyproject.toml` was upgraded from `^5.4.3` to `^5.4.6`.

Things done:
- Manually edit `pyproject.toml`
- Run `poetry lock --no-update`
- Remove obsolete comments in `config_loader.py`

## Motivation behind this PR?
Version 5.4.6 contains a fix for wrong type annotations. The fix
and additional type annotations were added in this PR:
https://github.com/python/typeshed/pull/5828

With an older version of `typtes-PyYAML`:
```
$ poetry show types-pyyaml
name         : types-pyyaml
version      : 5.4.5
description  : Typing stubs for PyYAML

$ mypy scanapi
scanapi/config_loader.py:59: error: Argument 2 to "add_constructor" has incompatible type "Callable[[scanapi.config_loader.Loader, Node], Any]"; expected "Callable[[yaml.loader.Loader, Node], Any]"  [arg-type]
scanapi/config_loader.py:59: error: Argument 3 to "add_constructor" has incompatible type "Type[scanapi.config_loader.Loader]"; expected "yaml.loader.Loader"  [arg-type]
Found 2 errors in 1 file (checked 22 source files)
```

with the latest one:
```
$ poetry show types-pyyaml
name         : types-pyyaml
version      : 5.4.6
description  : Typing stubs for PyYAML

$ mypy scanapi 
Success: no issues found in 22 source files
```

## What type of change is this?
Chore.

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
No issue
