### PR TITLE
fix: ignore python minors in setup-python and bump its version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,9 @@ jobs:
     name: black check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
-          python-version: 3.6.14
+          python-version: 3.6.x
       - name: Poetry Setup
         uses: snok/install-poetry@v1.1.1
         with:

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -4,9 +4,9 @@ jobs:
   poke-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
-          python-version: 3.6.14
+          python-version: 3.6.x
       - name: Poetry Setup
         uses: snok/install-poetry@v1.1.1
         with:
@@ -32,9 +32,9 @@ jobs:
   httpbin-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
-          python-version: 3.6.14
+          python-version: 3.6.x
       - name: Poetry Setup
         uses: snok/install-poetry@v1.1.1
         with:
@@ -60,9 +60,9 @@ jobs:
   demo-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
-          python-version: 3.6.14
+          python-version: 3.6.x
       - name: Poetry Setup
         uses: snok/install-poetry@v1.1.1
         with:


### PR DESCRIPTION
## Description
Ignore python minors in setup-python and bump setup-python version

## Motivation behind this PR?
#511

## What type of change is this?
Bug fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #511
