### PR TITLE
Fix/issue/512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Print test results summary in console [#497](https://github.com/scanapi/scanapi/issues/497)
 
+### Fixed
+- Fix CodeEvaluator's global context when calling eval [#515](https://github.com/scanapi/scanapi/pull/515)
+
 ## [2.6.1] - 2022-04-12
 ### Changed
 - Implement new details to help users on visualize related request data. [#506](https://github.com/scanapi/scanapi/pull/506)

--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -59,6 +59,9 @@ class CodeEvaluator:
     def _assert_code(cls, code, response):
         """Assert a Python code statement.
 
+        The eval's global context is enriched with the response to support
+        comprehensions.
+
         Args:
             code[string]: python code that ScanAPI needs to assert
             response[requests.Response]: the response for the current request
@@ -74,7 +77,8 @@ class CodeEvaluator:
             AssertionError: If python statement evaluates False
 
         """
-        ok = eval(code)  # noqa
+        global_context = {**globals(), **{"response": response}}
+        ok = eval(code, global_context)  # noqa
         return ok, None if ok else code.strip()
 
     @classmethod

--- a/tests/unit/evaluators/test_code_evaluator.py
+++ b/tests/unit/evaluators/test_code_evaluator.py
@@ -40,6 +40,7 @@ class TestEvaluate:
     test_data = [
         ("${{response.text == 'abcde'}}", (True, None)),
         ("${{response.url == 'http://test.com/'}}", (True, None),),
+        ("${{all(x in response.text for x in 'abc')}}", (True, None)),
         (
             "${{response.status_code == 300}}",
             (False, "response.status_code == 300"),


### PR DESCRIPTION
## Description
Enrich global context in eval calls in `CodeEvaluator._assert_code`

## Motivation behind this PR?
When writing an assert statement in scanapi which uses a list (or any other) comprehension, the code would fail.

## What type of change is this?
Bugfix

## Checklist
- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
Closes #512 
