### PR TITLE
Run lint on push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,8 @@
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 name: Lint check
 jobs:
   black:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   <a href="https://codecov.io/gh/scanapi/scanapi">
     <img alt="Codecov" src="https://img.shields.io/codecov/c/github/scanapi/scanapi">
   </a>
+  <a href="https://github.com/scanapi/scanapi/actions/workflows/lint.yml/badge.svg">
+    <img alt="LintCheck" src="https://github.com/scanapi/scanapi/workflows/Lint%20check/badge.svg?event=push">
+  </a>
   <a href="https://badge.fury.io/py/scanapi">
     <img alt="PyPI version" src="https://badge.fury.io/py/scanapi.svg">
   </a>


### PR DESCRIPTION
## Description
Enable lint action to run on pushes to the main branch. Previously, it was only running in the PRs.
Added status badge for showing if the lint check on main branch is passing.

## Motivation behind this PR?
closes #490 
Improves visibility of lint status

## What type of change is this?
Feature

## Checklist

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
Closes #490 
