### PR TITLE
Release v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.1] - 2022-04-12
 ### Changed
-- Implement new details to help users on visualize related request data.
+- Implement new details to help users on visualize related request data. [#506](https://github.com/scanapi/scanapi/pull/506)
 
 ### Fixed
 - Fix the `--browser` flag not working on macOS [#504](https://github.com/scanapi/scanapi/pull/504)
@@ -233,7 +235,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/camilamaia/scanapi/compare/v2.6.1...HEAD
+[2.6.1]: https://github.com/camilamaia/scanapi/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/camilamaia/scanapi/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/camilamaia/scanapi/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/camilamaia/scanapi/compare/v2.3.0...v2.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN pip install scanapi==2.6.0
+RUN pip install scanapi==2.6.1
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.6.0"
+version = "2.6.1"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Changed
- Implement new details to help users on visualize related request data. [#506](https://github.com/scanapi/scanapi/pull/506)

### Fixed
- Fix the `--browser` flag not working on macOS [#504](https://github.com/scanapi/scanapi/pull/504)
- Error on running ScanAPI. `ImportError: cannot import name 'soft_unicode' from 'markupsafe'` [#534](https://github.com/scanapi/scanapi/pull/534)