### PR TITLE
Release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.7.0] - 2022-06-02
 ### Deprecated
 - Drops support for Python 3.6 since its EOL was reached out in December last year [549](https://github.com/scanapi/scanapi/pull/549)
 
@@ -244,7 +246,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.6.2...HEAD
+[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/scanapi/scanapi/compare/v2.6.2...v2.7.0
 [2.6.2]: https://github.com/scanapi/scanapi/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/scanapi/scanapi/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/scanapi/scanapi/compare/v2.5.0...v2.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN pip install scanapi==2.6.2
+RUN pip install scanapi==2.7.0
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.6.2"
+version = "2.7.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["Camila Maia <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Deprecated
- Drops support for Python 3.6 since its EOL was reached out in December last year [549](https://github.com/scanapi/scanapi/pull/549)