### PR TITLE
fix: custom variable evaluated when defined on the path (#508)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v5.5.3
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     # It must match the flake8's version that is inside pyproject.toml
     rev: 3.8.4
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Custom variable evaluated when defined on the path [#508](https://github.com/scanapi/scanapi/issues/508)
 
 ## [2.8.0] - 2022-08-11
 ### Added

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -87,6 +87,12 @@ class RequestNode:
         path = str(self.spec.get(PATH_KEY, ""))
         full_url = join_urls(base_path, path)
 
+        self.endpoint.spec_vars.update(
+            self.spec.get(VARS_KEY, {}),
+            extras=dict(self.endpoint.spec_vars),
+            filter_responses=True,
+        )
+
         return self.endpoint.spec_vars.evaluate(full_url)
 
     @property
@@ -148,12 +154,6 @@ class RequestNode:
         method = self.http_method
         url = self.full_url_path
         console.print(f"\n- Making request {method} {url}", highlight=False)
-
-        self.endpoint.spec_vars.update(
-            self.spec.get(VARS_KEY, {}),
-            extras=dict(self.endpoint.spec_vars),
-            filter_responses=True,
-        )
 
         session = session_with_retry(self.retry)
         response = session.request(

--- a/tests/unit/tree/request_node/test_full_path_url.py
+++ b/tests/unit/tree/request_node/test_full_path_url.py
@@ -68,6 +68,22 @@ class TestFullPathUrl:
         request = RequestNode({"name": "foo", "path": []}, endpoint=endpoint)
         assert request.full_url_path == "http://foo.com/[]"
 
+    @mark.context(
+        "when the request specification has a URL that uses a custom variable"
+    )
+    @mark.it(
+        "should set the full url path as the concatenation of the custom variable "
+    )
+    def test_with_path_custom_var(self):
+        endpoint = EndpointNode(
+            {"name": "foo", "requests": [{}], "path": "http://foo.com/"}
+        )
+        request = RequestNode(
+            {"name": "foo", "path": "/${bar}", "vars": {"bar": "foo-bar"}},
+            endpoint=endpoint,
+        )
+        assert request.full_url_path == "http://foo.com/foo-bar"
+
     @mark.it("should call the evaluate method")
     def test_calls_evaluate(self, mocker, mock_evaluate):
         endpoint = EndpointNode(


### PR DESCRIPTION
## Description
Custom variable will be evaluated when defined in the path

## Motivation behind this PR?
#508

## What type of change is this?
Bug fix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR -->

- [X]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [X] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [X] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [X] Current PR does not significantly decrease the code coverage and docstring coverage.
- [X] My code follows the style guidelines of this project.
- [X] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [X] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #508


