### PR TITLE
Release v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.8.1] - 2023-03-02
 ### Fixed
 - Custom variable evaluated when defined on the path [#508](https://github.com/scanapi/scanapi/issues/508)
 - Add missing `--insecure` flag to cURL command on report based on request options [#555](https://github.com/scanapi/scanapi/pull/555)
@@ -253,7 +255,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.8.0...HEAD
+[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.8.1...HEAD
+[2.8.1]: https://github.com/scanapi/scanapi/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/scanapi/scanapi/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/scanapi/scanapi/compare/v2.6.2...v2.7.0
 [2.6.2]: https://github.com/scanapi/scanapi/compare/v2.6.1...v2.6.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN pip install scanapi==2.8.0
+RUN pip install scanapi==2.8.1
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.8.0"
+version = "2.8.1"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["The ScanAPI Organization <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Fixed
- Custom variable evaluated when defined on the path [#508](https://github.com/scanapi/scanapi/issues/508)
- Add missing `--insecure` flag to cURL command on report based on request options [#555](https://github.com/scanapi/scanapi/pull/555)