### PR TITLE
fix: content field didn't render properly on Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Content field not rendered properly on Chrome [#551](https://github.com/scanapi/scanapi/issues/551)
 
 ## [2.8.1] - 2023-03-02
 ### Fixed

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -677,24 +677,33 @@
 
         function tryParseJSON(string) {
             try {
-                var o = JSON.parse(string);
+                const o = JSON.parse(string);
                 if (o && typeof o === "object") {
                     return o;
                 }
             }
-            catch (e) { console.log("Invalid JSON Body: " + e) }
+            catch (e) { console.log("Invalid JSON Body: " + e); }
 
             return false;
-        };
+        }
 
-        for (var i = 0; i < all_json_bodies.length; i++) {
-            raw_json = all_json_bodies[i].innerText;
-            parsed_json = tryParseJSON(raw_json)
+        function decodeHtmlEntities(str) {
+            const txt = new DOMParser().parseFromString(str, "text/html");
+            return txt.documentElement.textContent;
+        }
+
+        for (const json_body of all_json_bodies) {
+            let raw_json = json_body.innerText;
+            if (!raw_json) {
+                // innerText is empty for hidden elements on Chrome.
+                raw_json = decodeHtmlEntities(json_body.innerHTML);
+            }
+            const parsed_json = tryParseJSON(raw_json);
 
             if (parsed_json) {
-                all_json_bodies[i].innerText = '';
-                all_json_bodies[i].appendChild(renderjson(parsed_json));
-                all_json_bodies[i].firstElementChild.setAttribute('data-content', raw_json);
+                json_body.innerText = '';
+                json_body.appendChild(renderjson(parsed_json));
+                json_body.firstElementChild.setAttribute('data-content', raw_json);
             }
         }
         /*
@@ -743,7 +752,7 @@
             })
         })
 
-        /* 
+        /*
             * Copying anchor URL.
             */
 


### PR DESCRIPTION
## Description
Fix the issue linked + a bit of cleanup of the code around

## Motivation behind this PR?
Fix #551

## What type of change is this?
bugfix

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [x]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [ ] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [x] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #551
