### PR TITLE
refactor(report): cleanup chrome fix (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Refactor
-- Improve performance & reliability of the fix in release 2.8.2 [PR #574](https://github.com/scanapi/scanapi/pulls/574)
 
 ## [2.8.2] - 2023-03-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Refactor
+- Improve performance & reliability of the fix in release 2.8.2 [PR #574](https://github.com/scanapi/scanapi/pulls/574)
 
 ## [2.8.2] - 2023-03-06
 ### Fixed

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -687,17 +687,8 @@
             return false;
         }
 
-        function decodeHtmlEntities(str) {
-            const txt = new DOMParser().parseFromString(str, "text/html");
-            return txt.documentElement.textContent;
-        }
-
         for (const json_body of all_json_bodies) {
-            let raw_json = json_body.innerText;
-            if (!raw_json) {
-                // innerText is empty for hidden elements on Chrome.
-                raw_json = decodeHtmlEntities(json_body.innerHTML);
-            }
+            let raw_json = json_body.textContent;
             const parsed_json = tryParseJSON(raw_json);
 
             if (parsed_json) {


### PR DESCRIPTION
Cleanup code linked to Chrome fix, turns out `.textContent` is all we need.

Tested on macOS on Safari, Chrome & Firefox.