### PR TITLE
dict.items()

### DIFF
--- a/scanapi/hide_utils.py
+++ b/scanapi/hide_utils.py
@@ -41,8 +41,7 @@ def _hide(http_msg, hide_settings):
         attribute (body, headers, url params)
 
     """
-    for http_attr in hide_settings:
-        secret_fields = hide_settings[http_attr]
+    for (http_attr, secret_fields) in hide_settings.items():
         for field in secret_fields:
             _override_info(http_msg, http_attr, field)
 


### PR DESCRIPTION
Using `dict.items()` is not discouraged by the official Python documentation. (https://docs.python.org/3/tutorial/datastructures.html#looping-techniques)