### PR TITLE
Release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.0] - 2024-11-10
 ### Changed
 - Change requests to httpx. [#208](https://github.com/scanapi/scanapi/issues/208)
 
@@ -271,7 +273,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.9.0...HEAD
+[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.10.0...HEAD
+[2.10.0]: https://github.com/scanapi/scanapi/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/scanapi/scanapi/compare/v2.8.2...v2.9.0
 [2.8.2]: https://github.com/scanapi/scanapi/compare/v2.8.1...v2.8.2
 [2.8.1]: https://github.com/scanapi/scanapi/compare/v2.8.0...v2.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN pip install scanapi==2.9.0
+RUN pip install scanapi==2.10.0
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scanapi"
-version = "2.9.0"
+version = "2.10.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = ["The ScanAPI Organization <cmaiacd@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Changed
- Change requests to httpx. [#208](https://github.com/scanapi/scanapi/issues/208)

### Deprecated
- Drops support for Python 3.7 and Python 3.8 since their EOL were reached out already [678](https://github.com/scanapi/scanapi/pull/678)