### PR TITLE
ci: upgrade codecov action

### DIFF
--- a/.github/workflows/pytest-and-codecov.yml
+++ b/.github/workflows/pytest-and-codecov.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -30,7 +35,7 @@ jobs:
         run: |
           make test
       - name: Upload coverage report to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ScanAPI repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run Examples
         uses: ./.github/actions/run_examples
         with:


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

- Upgrade codecov action version to v5
- Adds explicit permissions to the Pytest and Codecov workflow, to make it more secure
- Fix `httpx.ConnectTimeout` on tests. The session was not being mocked properly.

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->

Pipeline broken.

<img width="1587" alt="Image" src="https://github.com/user-attachments/assets/c7f97cb2-d9ea-4760-9723-cb9fdfd2d68b" />

Workflow run example: https://github.com/scanapi/scanapi/actions/runs/15777341084/job/44479954817?pr=725

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->

Fix of a pipeline

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [ ]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [x] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [ ] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #726
