### PR TITLE
ci: adapt pytest-and-codecov to handle forks

### DIFF
--- a/.github/workflows/pytest-and-codecov.yml
+++ b/.github/workflows/pytest-and-codecov.yml
@@ -21,21 +21,50 @@ jobs:
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@5db1cf9a59fb97c40a68accab29236f0da7e94db # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Poetry Setup
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # V1.4.1
         with:
           version: 2.1.3
+
       - name: Install Dependencies
         run: poetry install
+
       - name: Run Test and generate coverage report
         run: |
           make test
+
+      # Upload coverage report only if running on the main repository (not a fork)
       - name: Upload coverage report to codecov.io
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+      # For forks (without access to CODECOV_TOKEN), check coverage against a threshold and
+      # fail if below
+      - name: Check coverage threshold on forks
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          coverage=$(poetry run coverage report | tail -1 | awk '{print $4}' | sed 's/%//')
+          echo "Coverage is $coverage%"
+          threshold=98
+          echo "Threshold is $threshold%"
+
+          if [[ -z "$coverage" || ! "$coverage" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "❌ Coverage value invalid or empty. Failing job."
+            exit 1
+          fi
+
+          if (( $(echo "$coverage < $threshold" | bc -l) )); then
+            echo "❌ Coverage $coverage% is below threshold $threshold%, failing the job."
+            exit 1
+          else
+            echo "✅ Coverage is above threshold."
+          fi


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

This PR improves the GitHub Actions workflow `pytest-and-codecov` by:
- Skip Codecov upload on forks to avoid token access errors
- Add coverage threshold check on forks to fail if coverage drops below 98%
- Keep Codecov upload and normal checks on main repository

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
Forked repositories do not have access to the CODECOV_TOKEN, causing the Codecov upload step to fail. This change prevents those errors by skipping the upload on forks while still ensuring coverage quality via a threshold check.

For reference, see the failing run here:
https://github.com/scanapi/scanapi/actions/runs/15825517892/job/44604576216?pr=725

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Workflow / CI Improvement

## Checklist
<!-- If any particular item isn't necessary with your change, check it anyway so that the reviewer knows nothing is pending in the PR --> 

- [ ]  I have added a changelog entry / my PR does not need a new changelog entry. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog).
- [ ] I have added/updated unit tests. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests).
- [x] New and existing unit tests pass locally with my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [ ] I have self-documented code my changes by adding docstring(s) and comment(s). [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] Current PR does not significantly decrease the code coverage and docstring coverage.
- [x] My code follows the style guidelines of this project.
- [ ] I have run ScanAPI locally and manually tested my changes. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally).
- [x] I have squashed my commits. [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits).

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->

Closes #739 