### PR TITLE
fix(ci): add explicit permissions to workflows

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "*/10 * * * *"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,15 @@
+name: Lint check
+
 on:
   pull_request:
   push:
     branches:
       - main
-name: Lint check
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check:
     name: check code

--- a/.github/workflows/publish-to-production.yml
+++ b/.github/workflows/publish-to-production.yml
@@ -1,7 +1,13 @@
 name: Publish to Production
+
 on:
   release:
     types: [published]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build-n-publish:
     name: Publish to PyPI. Build and publish Python 🐍 distributions 📦

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,7 +1,13 @@
 name: Publish to Test PyPI
+
 on:
   push:
     branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build-n-publish-test-pypi:
     name: Test PyPI - Build and publish Python 🐍 distributions 📦

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,9 +1,15 @@
 name: ScanAPI Examples
+
 on:
   pull_request:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   poke-api:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR adds explicit `permissions` to all GitHub Actions workflows to restrict their default access levels. By default, workflows run with broad permissions, which can pose security risks—especially in public repositories. Setting explicit permissions follows GitHub’s recommended best practices and helps limit the potential impact of compromised workflows.

## Motivation behind this PR?

GitHub recommends setting explicit permissions for workflows to avoid unnecessary access to sensitive scopes such as `contents: write`. Without this, workflows may have more access than needed, which is a potential security vulnerability. This change proactively improves the CI/CD security posture of the project.

There is no related issue because this is a security hardening improvement.

## What type of change is this?

Security fix / CI hardening

## Checklist

* [x] A changelog entry was added, or this PR does not require one. [[Instructions](https://github.com/scanapi/scanapi/wiki/Changelog)](https://github.com/scanapi/scanapi/wiki/Changelog)
* [x] Unit tests were added or updated as needed, or not required for this change. [[Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests)](https://github.com/scanapi/scanapi/wiki/Writing-Tests)
* [x] All unit tests pass locally. [[Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
* [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [[Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
* [x] This PR does not significantly reduce code or docstring coverage.
* [x] Code follows the project’s style guidelines.
* [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [[Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally)](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally)
* [x] Commits were squashed, or squashing was not necessary (e.g., only one commit). [[Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits)](https://github.com/scanapi/scanapi/wiki/Squashing-Commits)

## Issue

There is no issue because it is a security vulnerability.