### PR TITLE
chore(dependabot): add semi-monthly version updates w/ 10d cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,42 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# - Version updates (pip):            1st & 15th 09:00 BRT, cooldown 10d, prefix "chore(deps)"
+# - Version updates (actions):        1st & 15th 09:00 BRT, cooldown 10d, prefix "ci(deps)"
+# - Security updates (pip & actions): ENABLE in repo Settings → Code security and analysis
+#     • Dependabot alerts
+#     • Dependabot security updates
+#   These run continuously/daily outside this file and bypass cooldown.
+# Docs:                               https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
 
 version: 2
+
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: weekly
-      time: "03:00"
-    open-pull-requests-limit: 10
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"        # 09:00 on the 1st and 15th
+      timezone: "America/Sao_Paulo"
+    cooldown:
+      default-days: 10               # Minimum release age before PRs are opened
+    open-pull-requests-limit: 5
     allow:
-    - dependency-type: direct
-    - dependency-type: indirect
-  - package-ecosystem: github-actions
-    directory: /
+      - dependency-type: direct
+      - dependency-type: indirect
+    labels: ["dependencies", "python"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
-      time: "03:00"
-    open-pull-requests-limit: 10
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"        # 09:00 on the 1st and 15th
+      timezone: "America/Sao_Paulo"
+    cooldown:
+      default-days: 10               # Same cooldown logic for Actions versions
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"


### PR DESCRIPTION
## Description

chore(dependabot): add semi-monthly version updates w/ 10d cooldown

- pip: 1st & 15th at 09:00 America/Sao_Paulo, cooldown 10 days, prefix `chore(deps)`
- GitHub Actions: 1st & 15th at 09:00 America/Sao_Paulo, cooldown 10 days, prefix `ci(deps)`
- Security updates (pip & actions): enable via Settings → Code security and analysis
  → Dependabot alerts + Dependabot security updates (run continuously, bypass cooldown)
- Set PR limit to 5 and add standard labels

This aligns Dependabot with ScanAPI’s release cadence: fast CVE response without noise from fresh releases, and predictable 1st/15th update windows.

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
Reduce dependabot[bot] commit noise and make the commit history readable and meaningful releases. #799 

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
chore/configuration change: updating Dependabot scheduling, cooldowns, commit prefixes, and grouping strategy.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally)
- [x] Commits were squashed, or squashing was not necessary (e.g., only one commit). [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #799 
