### PR TITLE
ci: prevent build-n-publish-test-pypi job from running on forks

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-n-publish-test-pypi:
-    if: github.repository == 'scanapi/scanapi
+    if: github.repository == 'scanapi/scanapi'
     name: Test PyPI - Build and publish Python 🐍 distributions 📦
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build-n-publish-test-pypi:
+    if: github.repository == 'scanapi/scanapi
     name: Test PyPI - Build and publish Python 🐍 distributions 📦
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
Issue #822 

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally)
- [x] Commits were squashed, or squashing was not necessary (e.g., only one commit). [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #822 
