### PR TITLE
docs: add wiki documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,14 +10,13 @@
 ## Checklist
 <!-- Please evaluate each item and mark all checkboxes. -->
 
-- [ ] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/wiki/Changelog)
-- [ ] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/wiki/Writing-Tests)
-- [ ] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally#tests)
-- [ ] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/wiki/First-Pull-Request#7-make-your-changes)
+- [ ] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
+- [ ] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
+- [ ] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-Locally.md#tests)
+- [ ] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
 - [ ] This PR does not significantly reduce code or docstring coverage.
 - [ ] Code follows the project’s style guidelines.
-- [ ] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/wiki/Run-ScanAPI-Locally)
-- [ ] Commits were squashed, or squashing was not necessary (e.g., only one commit). [Instructions](https://github.com/scanapi/scanapi/wiki/Squashing-Commits)
+- [ ] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-Locally.md)
 
 ## Issue
 <!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -18,7 +18,7 @@ jobs:
           pr-message: |
             Thank you for supporting ScanAPI, and congratulations on your first contribution! A project committer will shortly review your contribution.
 
-            In the mean time, if you haven't had a chance please skim over the [First Pull Request Guide](https://github.com/scanapi/scanapi/wiki/First-Pull-Request) which all pull requests must adhere to.
+            In the mean time, if you haven't had a chance please skim over the [First Pull Request Guide](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md) which all pull requests must adhere to.
 
             We hope to see you around!
           pr-label: First Contribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add button to copy data from the report page. [#295](https://github.com/scanapi/scanapi/pull/295)
 
 ### Changed
-- **BREAKING CHANGE:** Renamed `api.(yaml|json)` to `scanapi.yaml`. [#222](https://github.com/scanapi/scanapi/issues/20://github.com/scanapi/scanapi/pull/222)
+- **BREAKING CHANGE:** Renamed `api.(yaml|json)` to `scanapi.yaml`. [#222](https://github.com/scanapi/scanapi/pull/222)
 - **BREAKING CHANGE:**  Remove top-level `api` key in `scanapi.yaml`. [#231](https://github.com/scanapi/scanapi/pull/231)
 - **BREAKING CHANGE:** Renamed `project-name`, `hide-request` and `hide-response` to use underscore. [#228](https://github.com/scanapi/scanapi/issues/228)
 - **BREAKING CHANGE:** Changed command `scanapi spec-file.yaml` to `scanapi run spec-file.yaml`. [#247](https://github.com/scanapi/scanapi/pull/247)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking the time to contribute! 🙇‍♀️🙇‍♂️ Every little bit of help counts!
 
-Our Contributing documentation is available at our [Wiki](https://github.com/scanapi/scanapi/wiki). Please, check our [Newcomers Guide](https://github.com/scanapi/scanapi/wiki/Newcomers) to find some help with the first steps and also to be aware of our best practices.
+Our Contributing documentation is available at our [Wiki](https://github.com/scanapi/scanapi/blob/main/wiki/README.md). Please, check our [Newcomers Guide](https://github.com/scanapi/scanapi/blob/main/wiki/Newcomers.md) to find some help with the first steps and also to be aware of our best practices.
 
 Also, as one of the repositories under the `scanapi` GitHub organization, this repository follows
 the [ScanAPI Contributing Guideline](https://github.com/scanapi/contributors/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ _Made with [contrib.rocks](https://contrib.rocks)._
 </div>
 
 [github-issues]: https://github.com/scanapi/scanapi/issues
-[newcomers-guide]: https://github.com/scanapi/scanapi/wiki/Newcomers
+[newcomers-guide]: wiki/Newcomers.md
 [pip-installation]: https://pip.pypa.io/en/stable/installing/
 [scanapi-examples]: https://github.com/scanapi/examples
 [tutorial]: https://scanapi.dev/tutorials/step01

--- a/wiki/Changelog-Guide.md
+++ b/wiki/Changelog-Guide.md
@@ -1,0 +1,137 @@
+# Changelog Guide
+
+This guide explains how to add entries to the ScanAPI changelog.
+
+## Table of Contents
+
+- [What is a changelog?](#what-is-a-changelog)
+- [Why keep a changelog?](#why-keep-a-changelog)
+- [Who needs a changelog?](#who-needs-a-changelog)
+- [Where is ScanAPI changelog?](#where-is-scanapi-changelog)
+- [Guiding Principles](#guiding-principles)
+- [What warrants a changelog entry?](#what-warrants-a-changelog-entry)
+- [Writing good changelog entries](#writing-good-changelog-entries)
+- [How to add a changelog entry](#how-to-add-a-changelog-entry)
+
+## What is a changelog?
+
+A changelog is a file which contains a curated, chronologically ordered list of notable changes for each version of a project.
+
+## Why keep a changelog?
+
+To make it easier for users and contributors to see precisely what notable changes have been made between each release (or version) of the project.
+
+## Who needs a changelog?
+
+People do. Whether consumers or developers, the end users of software are human beings who care about what's in the software. When the software changes, people want to know why and how.
+
+## Where is ScanAPI changelog?
+
+ScanAPI changelog is available at [CHANGELOG.md](../CHANGELOG.md)
+
+## Guiding Principles
+
+- Changelogs are for humans, not machines.
+- There should be an entry for every single version.
+- The same types of changes should be grouped.
+- Versions and sections should be linkable.
+- The latest version comes first.
+- The release date of each version is displayed.
+
+## What warrants a changelog entry?
+
+- Security fixes must have a changelog entry with type set to security.
+- Any user-facing change should have a changelog entry.
+- Performance improvements should have a changelog entry.
+- Any docs-only changes should not have a changelog entry.
+- A fix for a bug introduced and then fixed in the same release should not have a changelog entry.
+- Any developer-facing change (e.g., refactoring, technical debt remediation, test suite changes) should not have a changelog entry. Example: "Fix flaky tests."
+
+## Writing good changelog entries
+
+A good changelog entry should be descriptive and concise. It should explain the change to a reader who has zero context about the change. If you have trouble making it both concise and descriptive, err on the side of descriptive.
+
+- **Bad**: Go to a project order.
+- **Good**: Show a user's starred projects at the top of the "Go to project" dropdown.
+
+The first example provides no context of where the change was made, or why, or how it benefits the user.
+
+- **Bad**: Copy (some text) to clipboard.
+- **Good**: Update the "Copy to clipboard" tooltip to indicate what's being copied.
+
+Again, the first example is too vague and provides no context.
+
+- **Bad**: Fixes and Improves CSS and HTML problems in mini pipeline graph and builds dropdown.
+- **Good**: Fix tooltips and hover states in mini pipeline graph and builds dropdown.
+
+The first example is too focused on implementation details. The user doesn't care that we changed CSS and HTML, they care about the end result of those changes.
+
+- **Bad**: Strip out nils in the Array of Commit objects returned from find_commits_by_message_with_elastic
+- **Good**: Fix 500 errors caused by Elasticsearch results referencing garbage-collected commits
+
+The first example focuses on how we fixed something, not on what it fixes. The rewritten version clearly describes the end benefit to the user (fewer 500 errors), and when (searching commits with Elasticsearch).
+
+Use your best judgement and try to put yourself in the mindset of someone reading the compiled changelog. Does this entry add value? Does it offer context about where and why the change was made?
+
+source: http://www.obsis.unb.br/gitlab/help/development/changelog.md
+
+## How to add a changelog entry
+
+The changelog is available in the file [CHANGELOG.md](../CHANGELOG.md).
+
+First you need to identify the type of your change. Type of changes:
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Fixed` for any bug fixes.
+- `Removed` for now removed features.
+- `Security` in case of vulnerabilities.
+
+You should always add new changelog entries in the `Unreleased` section. At release time, we will move the `Unreleased` section changes into a new release version section.
+
+So, inside the `Unreleased` section, you need to add your entry in the proper type section. If there is no section for it yet, you should add it.
+
+Let's see some examples. Let's suppose I have a new `Fixed` change to add, and current the CHANGELOG.md file is like this:
+
+```markdown
+## [Unreleased]
+### Added
+- JSON response is now properly rendered, instead of plain text. [#213](https://github.com/scanapi/scanapi/pull/213)
+
+### Changed
+- Renamed `api.(yaml|json)` to `scanapi.yaml`. [#222](https://github.com/scanapi/scanapi/pull/222)
+```
+
+I need to add a new `Fixed` section and add my entry there:
+
+```markdown
+## [Unreleased]
+### Added
+- JSON response is now properly rendered, instead of plain text. [#213](https://github.com/scanapi/scanapi/pull/213)
+
+### Changed
+- Renamed `api.(yaml|json)` to `scanapi.yaml`. [#222](https://github.com/scanapi/scanapi/pull/222)
+
+### Fixed
+- My changelog message here. [#<PR_number>](<pr_link>)
+```
+
+Note the order of the type sections matters. We have a lint that checks it, so it must be ordered Alphabetically. First Added, second Changed, third `Deprecated` and so on.
+
+Now, let's say I have one more entry to add and its type is `Added`. Since we already have a section for it, I will only add an extra line:
+
+```markdown
+## [Unreleased]
+### Added
+- JSON response is now properly rendered, instead of plain text. [#213](https://github.com/scanapi/scanapi/pull/213)
+- My other changelog message here. [#<PR_number>](<pr_link>)
+
+### Changed
+- Renamed `api.(yaml|json)` to `scanapi.yaml`. [#222](https://github.com/scanapi/scanapi/pull/222)
+
+### Fixed
+- My changelog message here. [#<PR_number>](<pr_link>)
+```
+
+This content is totally based on [keep a changelog website](https://keepachangelog.com/en/1.0.0/), since we follow its guidelines.

--- a/wiki/Deploy.md
+++ b/wiki/Deploy.md
@@ -1,0 +1,76 @@
+# Deploy
+
+Here you will find how to deploy a new production version of ScanAPI.
+
+Requirements:
+
+- Docker
+- Access to [camilamaia/scanapi repo on Docker Hub](https://hub.docker.com/r/camilamaia/scanapi)
+
+Steps:
+
+1. Release PR
+2. Deploy on GitHub
+3. Push Docker Images
+
+## 1. Release PR
+
+### Bump the lib Version
+
+Check the last release number at https://pypi.org/project/scanapi/#history
+
+Increment the version number in the `pyproject.toml` according to the version you have just got: https://github.com/scanapi/scanapi/blob/main/pyproject.toml#L3
+
+Also, increment the version number in the `Dockerfile` according to the version you have just got: https://github.com/scanapi/scanapi/blob/main/Dockerfile#L9
+
+### Update the CHANGELOG.md
+
+Add a new version title with the new version number and the current date, like [this](https://github.com/scanapi/scanapi/commit/86e89e6ab52bbf64e058c02dbfdbbb1500066bff#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR9-R10)
+
+And add the version links, like [this](https://github.com/scanapi/scanapi/commit/86e89e6ab52bbf64e058c02dbfdbbb1500066bff#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR69-R70)
+
+### Create the PR
+
+Create a PR named `Release <version>` containing these two changes above.
+
+[Example of Release PR](https://github.com/scanapi/scanapi/commit/86e89e6ab52bbf64e058c02dbfdbbb1500066bff)
+
+### Merge the PR
+
+Once the PR has been accepted and passed on all checks, merge it.
+
+## 2. Deploy on GitHub
+
+Deploy on GitHub is done when a [new release is created](https://docs.github.com/pt/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release).
+
+- The `tag version` should be `v<version>`, like for example `v0.0.18`.
+- The `release title` should be the same as tag version, (e.g `v0.0.18`).
+- The `release description` should be the content copied from the CHANGELOG.md file from the corresponding version section.
+
+Real examples are available at: https://github.com/scanapi/scanapi/releases.
+
+When the Deploy on GitHub is done, the new version will be also automatically deployed on [PyPI](https://pypi.org/project/scanapi/). Download the new ScanAPI version from PyPI and test if everything is working as expected.
+
+## 3. Push Docker Images
+
+On the ScanAPI repository, in the main branch, run the following commands from your terminal:
+
+```bash
+docker build -f Dockerfile -t camilamaia/scanapi:<version_number> -t camilamaia/scanapi:latest . --no-cache
+docker tag camilamaia/scanapi:<version_number> camilamaia/scanapi:<version_number>
+docker tag camilamaia/scanapi:latest camilamaia/scanapi:latest
+docker push camilamaia/scanapi:<version_number>
+docker push camilamaia/scanapi:latest
+```
+
+Example:
+
+```bash
+docker build -f Dockerfile -t camilamaia/scanapi:2.5.0 -t camilamaia/scanapi:latest . --no-cache
+docker tag camilamaia/scanapi:2.5.0 camilamaia/scanapi:2.5.0
+docker tag camilamaia/scanapi:latest camilamaia/scanapi:latest
+docker push camilamaia/scanapi:2.5.0
+docker push camilamaia/scanapi:latest
+```
+
+This will push the new images to Docker Hub.

--- a/wiki/EuroPython-2021.md
+++ b/wiki/EuroPython-2021.md
@@ -1,0 +1,85 @@
+# EuroPython 2021
+
+Welcome to the EuroPython 2021 ScanAPI sprint! First of all, thank you very much for the interest.
+
+The sprint will be run on the conference weekend: Saturday & Sunday Jul 31 & Aug 1 online. You can find everything you need to know about how the sprints at EuroPython are organized here: https://ep2021.europython.eu/events/sprints/
+
+So let's see how you can participate!
+
+## Table of Contents
+
+- [When is it going to happen?](#when-is-it-going-to-happen)
+- [Registration](#registration)
+- [Access EuroPython 2021 Conference System](#access-europython-2021-conference-system)
+- [Access ScanAPI Sprint room](#access-scanapi-sprint-room)
+- [Find an issue to tackle](#find-an-issue-to-tackle)
+- [Issue assignment](#issue-assignment)
+- [Run ScanAPI locally](#run-scanapi-locally)
+- [Submit your changes for review](#submit-your-changes-for-review)
+- [Wait for the reviews](#wait-for-the-reviews)
+- [All green](#all-green)
+- [Useful Links](#useful-links)
+
+## When is it going to happen?
+
+August 1st (Sunday): from 9 AM to 4 PM (CEST)
+
+## Registration
+
+First, you need to register at EuroPython Sprint Sessions:
+
+https://ep2021.europython.eu/registration/buy-tickets/#sprint.
+
+Sprints are free of charge but registration is required
+
+## Access EuroPython 2021 Conference System
+
+Follow the instructions to access the conference system:
+
+https://ep2021.europython.eu/setup/conference-system/
+
+## Access ScanAPI Sprint room
+
+Inside the Conference System, in the `Rooms` category of the left side bar, look for our Sprint Room `Sprint:​ 02 ScanAPI`. There, you will be able to chat with us live during the session.
+
+![image](https://user-images.githubusercontent.com/2728804/127670200-a73d3cd8-7c1a-4d7d-9584-95440a550845.png)
+
+## Find an issue to tackle
+
+Ok, it is time to find an issue to tackle! We prepared a dashboard containing all good issues to be tackled during sprint sessions:
+
+Dashboard: https://github.com/orgs/scanapi/projects/9?add_cards_query=is%3Aopen
+
+All issues that are in the `To Do` column and have no one assigned are possible issues for you. Find one that you feel comfortable with.
+
+If you have any questions about any issue, feel free to ask there, we will be more than happy to answer them!
+
+## Issue assignment
+
+Once you have picked one to tackle, go to the issue's page and send a comment saying that you are interested in working on it. This way, we can assign the issue to you.
+
+## Run ScanAPI locally
+
+Ok, it is time to start working. First things first, let's run ScanAPI locally, so you can have the development environment working: [Run ScanAPI locally doc](./Run-ScanAPI-Locally.md).
+
+## Submit your changes for review
+
+Once you have made your changes, it is time to open your pull request: [First-Pull-Request doc](./First-Pull-Request.md)
+
+## Wait for the reviews
+
+Ok, you are all set! You just need to wait for the reviews. Usually there are some back and forth in this phase. Don't worry, it is part of the process! We will interact with you till we have a result that is ready for production.
+
+## All green
+
+What happens when my PR was accepted and all checks are passing? We will merge the PR as soon as possible. So you don't need to do anything else. Congratulations, now you are an official ScanAPI contributor!
+
+## Useful Links
+
+- Website: https://scanapi.dev
+- Official documentation: https://scanapi.dev/docs.html
+- Official tutorial: https://scanapi.dev/tutorials/step01.html
+- Discord Server: https://discord.scanapi.dev
+- Twitter: http://twitter.com/scanapi_
+- EuroPython 2021 Sprints: https://ep2021.europython.eu/events/sprints/
+- EuroPython 2021 Registration: https://ep2021.europython.eu/registration/buy-tickets/#sprint

--- a/wiki/First-Pull-Request.md
+++ b/wiki/First-Pull-Request.md
@@ -1,0 +1,130 @@
+# First Pull Request
+
+How to submit a pull request:
+
+- [1. Create a GitHub Account](#1-create-a-github-account)
+- [2. Install Git](#2-install-git)
+- [3. Fork the Project](#3-fork-the-project)
+- [4. Clone your Fork](#4-clone-your-fork)
+- [5. Create a New Branch](#5-create-a-new-branch)
+- [6. Run ScanAPI locally](#6-run-scanapi-locally)
+- [7. Make your changes](#7-make-your-changes)
+- [8. Test your changes](#8-test-your-changes)
+- [9. Commit and push your changes](#9-commit-and-push-your-changes)
+- [10. Add changelog entries](#10-add-changelog-entries)
+- [11. Create a GitHub PR](#11-create-a-github-pr)
+- [12. Update your branch if needed](#12-update-your-branch-if-needed)
+
+### 1. Create a GitHub Account
+
+Make sure you have a [GitHub account](https://github.com/join)
+
+### 2. Install Git
+
+Make sure you have [Git installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+
+### 3. Fork the Project
+
+[Fork the ScanAPI repository](https://guides.github.com/activities/forking/)
+
+### 4. Clone your Fork
+
+[Clone](https://docs.github.com/en/enterprise/2.13/user/articles/cloning-a-repository) your fork locally
+
+### 5. Create a New Branch
+
+Go into the ScanAPI folder:
+
+```bash
+$ cd scanapi
+```
+
+And create a new branch:
+
+```bash
+$ git switch -c <issue_number>
+```
+
+### 6. Run ScanAPI locally
+
+[Run ScanAPI locally](Run-ScanAPI-Locally.md)
+
+### 7. Make your changes
+
+Now is the step where you can implement your changes in the code.
+
+It is important to notice that we document our code using [docstrings](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring). Modules, classes, functions, and methods should be documented. Your changes should also be well documented and should reflect updated docstrings if any of the params were changed for a class/attributes or even functions.
+
+We follow the given pattern below to keep consistency in the docstrings:
+
+```python
+class Example:
+    """Explain the purpose of the class
+
+    Attributes:
+        spec[dict]: Short explanation here
+        parent[type, optional]: Short explanation here
+
+    """
+
+    def __init__(self, spec, parent=None):
+        self.spec = spec
+        self.parent = parent
+
+    def foobar(self, field_name):
+        """Purpose of the function
+
+        Args:
+            field_name[str]: Short explanation here
+
+        Returns:
+            value[str]: Short explanation here
+
+        """
+        value = field_name.get('node')
+        return value
+```
+
+One last thing to keep in mind while self-documenting code with docstrings that you can ignore docstrings in property decorators and magic methods.
+
+### 8. Test your changes
+
+#### 8.1 Write new tests
+
+Make sure you have created the necessary tests for every new change you made. Please, visit the page [Writing Tests](Writing-Tests.md) to find the instructions of how to create tests
+
+#### 8.2 Make sure all tests passed
+
+[Run all the tests](Run-ScanAPI-Locally.md#tests) and make sure that they all passed.
+
+PRs will not be merged if there is any test missing or failing.
+
+### 9. Commit and push your changes
+
+Commit the changes:
+
+```bash
+$ git commit -a -m "<commit_message>"
+```
+
+We encourage you to follow these rules to write great commit messages: https://www.conventionalcommits.org/en/v1.0.0/
+
+Push your commit to GitHub
+
+```bash
+$ git push --set-upstream origin <issue_number>
+```
+
+Create the number of changes/commits you need and push them.
+
+### 10. Add changelog entries
+
+[Add a CHANGELOG entry](Changelog-Guide.md)
+
+### 11. Create a GitHub PR
+
+[Create a GitHub PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+
+### 12. Update your branch if needed.
+
+Make sure your branch is updated with main.

--- a/wiki/Managing-Dependencies.md
+++ b/wiki/Managing-Dependencies.md
@@ -1,0 +1,23 @@
+# Managing Dependencies
+
+We use [uv](https://docs.astral.sh/uv/) to manage dependencies. Please check the sections below for instructions on adding or removing dependencies.
+
+## Add a new dependency
+
+```bash
+$ uv add <library>
+```
+
+Official documentation: https://docs.astral.sh/uv/concepts/projects/dependencies/#adding-dependencies
+
+## Remove a dependency
+
+```bash
+$ uv remove <library>
+```
+
+Official documentation: https://docs.astral.sh/uv/concepts/projects/dependencies/#removing-dependencies
+
+## More
+
+Please, check the [uv's Official Documentation](https://docs.astral.sh/uv/) for more information

--- a/wiki/Mentored-Sprints-at-PyCon-India-2021.md
+++ b/wiki/Mentored-Sprints-at-PyCon-India-2021.md
@@ -1,0 +1,73 @@
+# Mentored Sprints at PyCon India 2021
+
+Welcome to the [Mentored Sprints at PyCon India 2021](https://www.mentored-sprints.dev/events/pyconindia-2021-09-20/). We are thrilled to have you.
+
+The sprint will be run on: Monday, September 20, 2021 from 16:00 IST to 20:00 IST.
+
+## Table of Contents
+
+- [Access Mentored Sprints at PyCon India 2021 System](#access-mentored-sprints-at-pycon-india-2021-system)
+- [Access ScanAPI Sprint room](#access-scanapi-sprint-room)
+- [Find an issue to tackle](#find-an-issue-to-tackle)
+- [Issue assignment](#issue-assignment)
+- [Run ScanAPI locally](#run-scanapi-locally)
+- [Submit your changes for review](#submit-your-changes-for-review)
+- [Wait for the reviews](#wait-for-the-reviews)
+- [All green](#all-green)
+- [Useful Links](#useful-links)
+
+## Access Mentored Sprints at PyCon India 2021 System
+
+Sprints are conducted over [hopin](https://hopin.com/). If you had registered for the sprints, you would have got an email to join the platform.
+
+The async communication channel is [Zulip](https://zulip.com/). `2021/devsprints` stream has a [topic](https://pyconindia.zulipchat.com/#narrow/stream/298853-2021.2Fdevsprints/topic/ScanAPI) for ScanAPI.
+
+Zulip streams are great for async conversation and discussion around the project/bug/feature requests.
+
+## Access ScanAPI Sprint room
+
+In hopin session's you would find a room titled ScanAPI. The room is dedicated to help pair program on a particular issue, any feature request that you might want to talk about, or just API testing in general.
+
+## Find an issue to tackle
+
+Ok, it is time to find an issue to tackle! We prepared a dashboard containing all good issues to be tackled during sprint sessions:
+
+[Dashboard](https://github.com/orgs/scanapi/projects/9?add_cards_query=is%3Aopen)
+
+All issues that are in the `To Do` column and have no one assigned are possible issues for you. Find one that you feel comfortable with.
+
+Issues mentioned on the dashboard are the ones that you can complete during the sprint duration but if you want to pick something a bit more challenging feel free to look into the [issues](https://github.com/scanapi/scanapi/issues) of the repo.
+
+If you have any questions about any issue, feel free to ask there, we will be more than happy to answer them!
+
+## Issue assignment
+
+Once you have picked one to tackle, go to the issue's page and send a comment saying that you are interested in working on it. This way, we can assign the issue to you.
+
+## Run ScanAPI locally
+
+Ok, it is time to start working. First things first, let's run ScanAPI locally, so you can have the development environment working:
+
+[Guide to Run ScanAPI Locally](Run-ScanAPI-Locally.md)
+
+## Submit your changes for review
+
+Once you have made your changes, it is time to open your pull request:
+
+[Guide to First Pull Request](First-Pull-Request.md)
+
+## Wait for the reviews
+
+Ok, you are all set! You just need to wait for the reviews. Usually, there is some back and forth in this phase. Don't worry, it is part of the process! We will interact with you till we have a result that is ready for production.
+
+## All green
+
+What happens when my PR was accepted and all check is passing? We will merge the PR as soon as possible. So you don't need to do anything else. Congratulations, now you are an official ScanAPI contributor!
+
+## Useful Links
+
+- [Website](https://scanapi.dev)
+- [Official documentation](https://scanapi.dev/docs.html)
+- [Official tutorial](https://scanapi.dev/tutorials/step01.html)
+- [Discord Server](https://discord.scanapi.dev)
+- [Twitter](http://twitter.com/scanapi_)

--- a/wiki/Newcomers.md
+++ b/wiki/Newcomers.md
@@ -1,0 +1,14 @@
+# Newcomers
+
+First of all, thanks for taking the time to contribute! Every little bit of help counts! 🙇‍♀️🙇‍♂️
+
+We tried to put together some documentation to help your onboarding. We hope this will walk you through everything that is needed to become a contributor.
+
+If you think any information is missing or not right, we encourage you to [create an issue](https://github.com/scanapi/scanapi/issues) to alert us about it!
+
+## Contents
+
+- [First Pull Request](First-Pull-Request.md)
+- [Run ScanAPI Locally](Run-ScanAPI-Locally.md)
+- [Changelog Guide](Changelog-Guide.md)
+- [Writing Tests](Writing-Tests.md)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,37 @@
+# ScanAPI Wiki
+
+Welcome to the ScanAPI wiki! 📃 This wiki contains contributing guides and how-tos for the ScanAPI main repository.
+
+## Content
+
+### For New Contributors
+
+- [Newcomers](Newcomers.md) - Introduction for new contributors
+  - [First Pull Request](First-Pull-Request.md) - How to submit your first pull request
+  - [Run ScanAPI Locally](Run-ScanAPI-Locally.md) - How to run ScanAPI locally
+  - [Changelog Guide](Changelog-Guide.md) - How to add changelog entries
+  - [Writing Tests](Writing-Tests.md) - Guide for writing tests
+
+### Project Management
+
+- [Managing Dependencies](Managing-Dependencies.md) - How to manage dependencies with uv
+- [Deploy](Deploy.md) - How to deploy new versions
+
+### Sprints and Events
+
+- [Sprints](Sprints.md) - Information about sprints
+  - [EuroPython 2021](EuroPython-2021.md) - EuroPython 2021 sprint
+  - [Mentored Sprints at PyCon India 2021](Mentored-Sprints-at-PyCon-India-2021.md) - PyCon India mentored sprints
+
+---
+
+## Useful Links
+
+- 🌐 Website: https://scanapi.dev
+- 📚 Official documentation: https://scanapi.dev/docs.html
+- 📖 Official tutorial: https://scanapi.dev/tutorials/step01.html
+- 🔍 DeepWiki: https://deepwiki.com/scanapi/scanapi
+- 💬 Discord Server: https://discord.scanapi.dev
+- 🐦 Twitter: http://twitter.com/scanapi_
+- 📦 PyPI: https://pypi.org/project/scanapi/
+- 🐳 Docker Hub: https://hub.docker.com/r/camilamaia/scanapi

--- a/wiki/Run-ScanAPI-Locally.md
+++ b/wiki/Run-ScanAPI-Locally.md
@@ -1,0 +1,82 @@
+# Run ScanAPI Locally
+
+## Install
+
+### Requirements:
+
+- [Python 3.10.x+](https://www.python.org/downloads/)
+- [uv](https://docs.astral.sh/uv/#installation)
+
+Fork or clone the repository and enter into the project's folder:
+
+```bash
+$ git clone git@github.com:scanapi/scanapi.git
+$ cd scanapi
+```
+
+Install the dependencies:
+
+```bash
+$ make install
+```
+
+## Run
+
+Run the ScanAPI:
+
+```bash
+$ uv run scanapi
+```
+
+For help, run:
+
+```bash
+$ uv run scanapi --help
+```
+
+As you may have noticed, you need an API specification file to run ScanAPI properly. Otherwise you will receive this error:
+
+```bash
+$ uv run scanapi
+ERROR:scanapi:Could not find API spec file: scanapi.yaml.
+[Errno 2] No such file or directory: 'scanapi.yaml'
+```
+
+For that, we have the [ScanAPI Examples](https://github.com/scanapi/examples) repository, with some API specification examples that you can use.
+
+### Clone ScanAPI Examples
+
+In another terminal tab, outside `scanapi` folder, clone the [ScanAPI examples](https://github.com/scanapi/examples) project:
+
+```bash
+$ git clone git@github.com:scanapi/examples.git
+```
+
+Your workspace should have these both folders now:
+
+```bash
+▶ ls
+scanapi               examples
+```
+
+Run the ScanAPI for the API example you prefer:
+
+**PokèAPI**
+
+```bash
+$ uv run scanapi run examples/pokeapi/scanapi.yaml -c examples/pokeapi/scanapi.conf -o examples/pokeapi/scanapi-report.html
+```
+
+**Demo-API**
+
+```bash
+$ uv run scanapi run examples/demo-api/scanapi.yaml -c examples/demo-api/scanapi.conf -o examples/demo-api/scanapi-report.html
+```
+
+## Tests
+
+To run the tests, run:
+
+```bash
+$ make test
+```

--- a/wiki/Sprints.md
+++ b/wiki/Sprints.md
@@ -1,0 +1,6 @@
+# Sprints
+
+## Contents
+
+- [EuroPython 2021](EuroPython-2021.md)
+- [Mentored Sprints at PyCon India 2021](Mentored-Sprints-at-PyCon-India-2021.md)

--- a/wiki/Writing-Tests.md
+++ b/wiki/Writing-Tests.md
@@ -1,0 +1,242 @@
+# Writing Tests
+
+Tests are located in the `tests` folder. We only have unit tests in the project for now.
+
+## Table of Contents
+
+- [Unit Tests](#unit-tests)
+  - [Tools](#tools)
+  - [Folder Structure](#folder-structure)
+  - [How to create a test](#how-to-create-a-test)
+  - [Examples](#examples)
+
+## Unit Tests
+
+### Tools
+
+For unit tests, we use [pytest](https://docs.pytest.org/en/stable/) and [pytest-it](https://pypi.org/project/pytest-it/). If you are not familiar with these tools, please take a quick look at their official docs, it might help you:
+
+- [pytest](https://docs.pytest.org/en/stable/)
+- [pytest-it](https://pypi.org/project/pytest-it/)
+
+### Folder Structure
+
+Unit tests are located in the `tests/unit` folder.
+
+Test files should follow the same structure as the project itself and their names should start with `test_`. For example:
+
+- File: `scanapi/evaluators/code_evaluator.py`. Test File `tests/unit/evaluators/test_code_evaluator.py`
+- File: `scanapi/scan.py`. Test file: `tests/unit/test_scan.py`
+
+If the test file gets too long, we create a folder and split the tests there. For example:
+
+- File: `scanapi/tree/endpoint_node.py`.
+- Test Files:
+  - `tests/unit/tree/endpoint_node/test_delay.py`
+  - `tests/unit/tree/endpoint_node/test_get_requests.py`
+  - `tests/unit/tree/endpoint_node/test_get_specs.py`
+  - ...
+
+### How to create a test
+
+We create a separate class for each method we want to test. We add two `describe` decorators for this test class:
+
+- one for the class name that the method belongs to;
+- another for the method name itself.
+
+We use `context` decorators to specify different scenarios. And, we use the `it` decorator for every test case, to describe what is the expected behavior.
+
+Let's say we have the following file to be tested:
+
+```python
+# my_file.py
+class MyClassA:
+    def method_1(self):
+        pass
+
+    def method_2(self):
+        pass
+
+class MyClassB:
+    def method_3(self):
+        pass
+```
+
+The test file `test_my_file.py` would look like something similar to this:
+
+```python
+from pytest import mark
+
+
+@mark.describe("my class a")
+@mark.describe("method_1")
+class TestMethod1:
+    @mark.context("when scenario A happens")
+    @mark.it("should do this")
+    def test_should_do_this(self):
+        # test here
+        pass
+
+    @mark.context("when scenario A happens")
+    @mark.it("should not do that")
+    def test_should_not_do_that(self):
+        # test here
+        pass
+
+    @mark.context("when scenario B happens")
+    @mark.it("should do another thing")
+    def test_should_do_another_thing(self):
+        # test here
+        pass
+
+
+@mark.describe("my class a")
+@mark.describe("method_2")
+class TestMethod2:
+    @mark.context("when scenario C happens")
+    @mark.it("should do something")
+    def test_should_do_something(self):
+        # test here
+        pass
+
+    @mark.context("when scenario D happens")
+    @mark.it("should do another thing")
+    def test_should_do_another_thing(self):
+        # test here
+        pass
+
+
+@mark.describe("my class b")
+@mark.describe("method_3")
+class TestMethod3:
+    @mark.context("when scenario E happens")
+    @mark.it("should do something")
+    def test_should_do_something(self):
+        # test here
+        pass
+
+    @mark.context("when scenario F happens")
+    @mark.it("should do another thing")
+    def test_should_do_another_thing(self):
+        # test here
+        pass
+```
+
+The output for this would be like:
+
+```
+* tests/unit/test_my_file.py...
+- Describe: My class a...
+
+  - Describe: Method_1...
+
+    - Context: When scenario a happens...
+      - ✓ It: should do this
+      - ✓ It: should not do that
+
+    - Context: When scenario b happens...
+      - ✓ It: should do another thing
+
+  - Describe: Method_2...
+
+    - Context: When scenario c happens...
+      - ✓ It: should do something
+
+    - Context: When scenario d happens...
+      - ✓ It: should do another thing
+
+- Describe: My class b...
+
+  - Describe: Method_3...
+
+    - Context: When scenario e happens...
+      - ✓ It: should do something
+
+    - Context: When scenario f happens...
+      - ✓ It: should do another thing
+```
+
+Sometimes we have files without classes. It is not a problem, we can change the `describe` decorator to point out the file name
+
+Let's say we have the following file to be tested:
+
+```python
+# `my_file.py`
+def method_1(self):
+    pass
+
+
+def method_2(self):
+    pass
+```
+
+The test file `test_my_file.py` would look like something similar to this:
+
+```python
+from pytest import mark
+
+
+@mark.describe("my file")
+@mark.describe("method_1")
+class TestMethod1:
+    @mark.context("when scenario A happens")
+    @mark.it("should do this")
+    def test_should_do_this(self):
+        # test here
+        pass
+
+    @mark.context("when scenario A happens")
+    @mark.it("should not do that")
+    def test_should_not_do_that(self):
+        # test here
+        pass
+
+    @mark.context("when scenario B happens")
+    @mark.it("should do another thing")
+    def test_should_do_another_thing(self):
+        # test here
+        pass
+
+@mark.describe("my file")
+@mark.describe("method_2")
+class TestMethod2:
+    @mark.context("when scenario C happens")
+    @mark.it("should do something")
+    def test_should_do_something(self):
+        # test here
+        pass
+
+    @mark.context("when scenario D happens")
+    @mark.it("should do another thing")
+    def test_should_do_another_thing(self):
+        # test here
+        pass
+```
+
+The output for it would be like:
+
+```
+* tests/unit/test_my_file.py...
+- Describe: My file...
+
+  - Describe: Method_1...
+
+    - Context: When scenario a happens...
+      - ✓ It: should do this
+      - ✓ It: should not do that
+
+    - Context: When scenario b happens...
+      - ✓ It: should do another thing
+
+  - Describe: Method_2...
+
+    - Context: When scenario c happens...
+      - ✓ It: should do something
+
+    - Context: When scenario d happens...
+      - ✓ It: should do another thing
+```
+
+### Examples
+
+Do you wanna see real examples? Check the folder https://github.com/scanapi/scanapi/tree/main/tests/unit


### PR DESCRIPTION
## Description

This PR migrates the entire content from the GitHub Wiki (https://github.com/scanapi/scanapi/wiki) into the repository under a new `wiki/` directory. This improves maintainability and allows the documentation to be versioned alongside the code.

All wiki pages have been converted to Markdown files with enhanced navigation through table of contents and clickable section links.

The wiki content was placed in a separate `wiki/` directory at the repository root (rather than inside the existing `documentation/` folder) to avoid interfering with the Read the Docs build and configuration.

## Motivation behind this PR?

Having the wiki content within the repository provides several benefits:
- Version control for documentation changes
- Documentation can be reviewed through PRs
- Easier to keep docs in sync with code changes
- Contributors can update documentation in the same workflow as code
- Documentation survives if the GitHub wiki is ever disabled

## What type of change is this?

Feature — Documentation improvement

## Changes Made

### Wiki Content Migration
- Migrated all pages from GitHub Wiki to `wiki/` directory
- Created 11 markdown files with complete wiki content
- Placed in separate `wiki/` folder to avoid conflicts with Read the Docs documentation structure

### Structural Changes
- **Removed**: `Home.md` — redundant with `README.md`
- **Removed**: `Squashing-Commits.md` — not needed anymore (the “squash and merge” option is the only one available to merge a PR nowadays)
- **Renamed**: `Changelog.md` → `Changelog-Guide.md` — to avoid confusion with actual `CHANGELOG.md`

### Content Updates
- **Updated all Poetry references to uv** throughout the documentation:
  - `Managing-Dependencies.md`: changed from `poetry add/remove` to `uv add/remove`
  - `Run-ScanAPI-Locally.md`: updated commands to use `uv run` and removed obsolete `make sh` step
  - Requirements updated to Python 3.10.x+ and uv
- **Updated Python version requirement**: changed from 3.6.1+ to 3.10.x+

### Navigation Improvements
- Added table of contents with anchor links to:
  - `First-Pull-Request.md`
  - `Writing-Tests.md`
  - `Changelog-Guide.md`
  - `EuroPython-2021.md`
- Added a new page:
  - `Mentored-Sprints-at-PyCon-India-2021.md`, linked from `Sprints.md` and `wiki/README.md`

### Cross-Reference Updates
- All internal wiki links updated to reference local `.md` files
  - `README.md`
  - `.github/pull_request_template.md`
  - `.github/workflows/first-interaction.yml`
  - `CONTRIBUTING.md`

## Checklist

- [x] A changelog entry was added, or this PR does not require one. (Documentation-only change)
- [x] Unit tests were added or updated as needed, or not required for this change. (Documentation-only change)
- [x] All unit tests pass locally. (Documentation-only change)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. (Documentation-only change)
- [x] This PR does not significantly reduce code or docstring coverage. (Documentation-only change)
- [x] Code follows the project's style guidelines. (Documentation follows Markdown standards)
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. (Documentation-only change)
- [x] Commits were squashed, or squashing was not necessary

## Issue

Closes #844