### PR TITLE
fix: update badge URL to current GitHub format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <img alt="Codecov" src="https://img.shields.io/codecov/c/github/scanapi/scanapi">
   </a>
   <a href="https://github.com/scanapi/scanapi/actions/workflows/lint.yml?query=branch%3Amain">
-    <img alt="LintCheck" src="https://github.com/scanapi/scanapi/workflows/Lint%20check/badge.svg?event=push">
+    <img alt="LintCheck" src="https://github.com/scanapi/scanapi/actions/workflows/lint.yml/badge.svg?branch=main">
   </a>
   <a href="https://github.com/scanapi/scanapi/actions/workflows/run-examples.yml?query=branch%3Amain">
     <img alt="Examples" src="https://github.com/scanapi/scanapi/actions/workflows/run-examples.yml/badge.svg?branch=main">


### PR DESCRIPTION
Good day

I noticed the GitHub Actions badge URL in README.md was using an outdated format. The badge was not displaying correctly because it was using `/workflows/.../badge.svg` instead of the current recommended format `/actions/workflows/.../badge.svg`.

This fix updates the LintCheck badge to use the proper GitHub badge URL format.

- Changed from `/workflows/.../badge.svg` to `/actions/workflows/.../badge.svg`
- Updated `event=push` to `branch=main` for proper status display

感谢你们的奉献，希望能提供帮助。如果我解决得有问题或有待商妥的地方，请在下面留言，我会来处理。

Warmly,

Closes #879 