### PR TITLE
test: Add scan tests for _write_report usage error branches

### DIFF
--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -269,7 +269,6 @@ class TestScan:
                 scan()
 
         mock_write_report.assert_called_once_with([response], False)
-        assert excinfo.type == SystemExit
         assert excinfo.value.code == ExitCode.USAGE_ERROR
         assert "bad template" in caplog.text
 
@@ -308,6 +307,5 @@ class TestScan:
                 scan()
 
         mock_write_report.assert_called_once_with([response], False)
-        assert excinfo.type == SystemExit
         assert excinfo.value.code == ExitCode.USAGE_ERROR
         assert "invalid python code" in caplog.text

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -6,7 +6,13 @@ import requests
 import yaml
 from pytest import fixture, mark, raises
 
-from scanapi.errors import EmptyConfigFileError, InvalidKeyError
+from scanapi.errors import (
+    BadConfigurationError,
+    EmptyConfigFileError,
+    InvalidKeyError,
+    InvalidPythonCodeError,
+)
+from scanapi.exit_code import ExitCode
 from scanapi.scan import scan
 
 log = logging.getLogger(__name__)
@@ -229,3 +235,79 @@ class TestScan:
 
         assert excinfo.type == SystemExit
         assert excinfo.value.code == 0
+
+    @mark.context(
+        "when _write_report raises BadConfigurationError"
+    )
+    @mark.it("should log an error and exit with usage error")
+    def test_should_log_error_and_exit_with_usage_error_when_bad_configuration_error(
+        self, mocker, caplog, response
+    ):
+        mocker.patch(
+            "scanapi.scan.settings",
+            {
+                "spec_path": "",
+                "no_report": False,
+                "open_browser": False,
+                "output_path": "",
+                "template": None,
+            },
+        )
+
+        mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
+        mock_load_config_file.return_value = {"endpoints": []}
+        mocker.patch("scanapi.scan.EndpointNode.__init__", return_value=None)
+        mocker.patch("scanapi.scan.EndpointNode.run", return_value=[response])
+        mock_write_report = mocker.patch(
+            "scanapi.scan._write_report",
+            side_effect=BadConfigurationError("bad template"),
+        )
+
+        caplog.clear()
+        with caplog.at_level(logging.ERROR, logger="scanapi.scan"):
+            with raises(SystemExit) as excinfo:
+                scan()
+
+        mock_write_report.assert_called_once_with([response], False)
+        assert excinfo.type == SystemExit
+        assert excinfo.value.code == ExitCode.USAGE_ERROR
+        assert "bad template" in caplog.text
+
+    @mark.context(
+        "when _write_report raises InvalidPythonCodeError"
+    )
+    @mark.it("should log an error and exit with usage error")
+    def test_should_log_error_and_exit_with_usage_error_when_invalid_python_code_error(
+        self, mocker, caplog, response
+    ):
+        mocker.patch(
+            "scanapi.scan.settings",
+            {
+                "spec_path": "",
+                "no_report": False,
+                "open_browser": False,
+                "output_path": "",
+                "template": None,
+            },
+        )
+
+        mock_load_config_file = mocker.patch("scanapi.scan.load_config_file")
+        mock_load_config_file.return_value = {"endpoints": []}
+        mocker.patch("scanapi.scan.EndpointNode.__init__", return_value=None)
+        mocker.patch("scanapi.scan.EndpointNode.run", return_value=[response])
+        mock_write_report = mocker.patch(
+            "scanapi.scan._write_report",
+            side_effect=InvalidPythonCodeError(
+                "invalid python code", "foo()"
+            ),
+        )
+
+        caplog.clear()
+        with caplog.at_level(logging.ERROR, logger="scanapi.scan"):
+            with raises(SystemExit) as excinfo:
+                scan()
+
+        mock_write_report.assert_called_once_with([response], False)
+        assert excinfo.type == SystemExit
+        assert excinfo.value.code == ExitCode.USAGE_ERROR
+        assert "invalid python code" in caplog.text

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -264,9 +264,10 @@ class TestScan:
         )
 
         caplog.clear()
-        with caplog.at_level(logging.ERROR, logger="scanapi.scan"):
-            with raises(SystemExit) as excinfo:
-                scan()
+        with caplog.at_level(
+            logging.ERROR, logger="scanapi.scan"
+        ), raises(SystemExit) as excinfo:
+            scan()
 
         mock_write_report.assert_called_once_with([response], False)
         assert excinfo.value.code == ExitCode.USAGE_ERROR
@@ -302,9 +303,10 @@ class TestScan:
         )
 
         caplog.clear()
-        with caplog.at_level(logging.ERROR, logger="scanapi.scan"):
-            with raises(SystemExit) as excinfo:
-                scan()
+        with caplog.at_level(
+            logging.ERROR, logger="scanapi.scan"
+        ), raises(SystemExit) as excinfo:
+            scan()
 
         mock_write_report.assert_called_once_with([response], False)
         assert excinfo.value.code == ExitCode.USAGE_ERROR


### PR DESCRIPTION
## Summary
This PR adds focused unit tests to exercise the missing exception handling branch in `scan.py:81` for:

- `BadConfigurationError`  
- `InvalidPythonCodeError`  

Both tests assert:
- `SystemExit` is raised  
- Exit code is `ExitCode.USAGE_ERROR`  
- Error is logged by the `scanapi.scan` logger  

Closes #881
---

## Result:

### Test Results
```bash
pytest test_scan.py
```

**Result:**
- 9 passed  

<img width="464" height="382" alt="image" src="https://github.com/user-attachments/assets/b89ce96a-f44f-4b62-a23d-4a8423663058" />


---

### Coverage
```bash
pytest test_scan.py --cov=scanapi.scan --cov-report=term-missing
```
<img width="918" height="779" alt="image" src="https://github.com/user-attachments/assets/4922b35b-2549-4d04-acb1-d49a72802ee1" />

---

<img width="919" height="535" alt="image" src="https://github.com/user-attachments/assets/74d9e22d-0369-4af3-80a7-e41866892f18" />

**Result:**
- `scan.py` = **100% coverage** (53 statements, 0 missed)  

---

Hi @camilamaia ,
Please review these changes and let me know if any further modifications are needed. If you notice any issues, please leave a comment below and I will address them. Thank you!