### PR TITLE
fix(ci): Run codecov upload on push to main

### DIFF
--- a/.github/workflows/pytest-and-codecov.yml
+++ b/.github/workflows/pytest-and-codecov.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Upload coverage report only if running on the main repository (not a fork)
       - name: Upload coverage report to codecov.io
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == "push" || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       # For forks (without access to CODECOV_TOKEN), check coverage against a threshold and
       # fail if below
       - name: Check coverage threshold on forks
-        if: github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event_name == "pull_request" && github.event.pull_request.head.repo.full_name != github.repository
         run: |
           coverage=$(uv run coverage report | tail -1 | awk '{print $4}' | sed 's/%//')
           echo "Coverage is $coverage%"


### PR DESCRIPTION
…rigger on push events. Restrict fork threshold check to pull_request events only. Closes #892

## Description
This PR updates the CI workflow to ensure Codecov coverage reports are uploaded on pushes to the `main` branch.

Currently, the `Upload coverage report to codecov.io` step only runs on `pull_request` events because it relies on `github.event.pull_request`, which is undefined for `push` events. This causes coverage reports to be missing after merges or direct pushes to `main`.

**Changes:**
- Modified the `if` condition for the upload step to also trigger on `push` events.
- Added a guard to the fork threshold step to ensure it only runs on `pull_request` events.

## Motivation behind this PR?
Fixes #892. Without this change, coverage metrics are not reported to Codecov after PRs are merged, making it difficult to track coverage trends on the main branch.

## What type of change is this?
Bug Fix (CI workflow)

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [ ] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [ ] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [ ] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [ ] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [ ] This PR does not significantly reduce code or docstring coverage.
- [ ] Code follows the project’s style guidelines.
- [ ] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
Closes #892
