### PR TITLE
ci: fix codecov upload skipped on push to main

### DIFF
--- a/.github/workflows/pytest-and-codecov.yml
+++ b/.github/workflows/pytest-and-codecov.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Upload coverage report only if running on the main repository (not a fork)
       - name: Upload coverage report to codecov.io
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       # For forks (without access to CODECOV_TOKEN), check coverage against a threshold and
       # fail if below
       - name: Check coverage threshold on forks
-        if: github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
           coverage=$(uv run coverage report | tail -1 | awk '{print $4}' | sed 's/%//')
           echo "Coverage is $coverage%"


### PR DESCRIPTION
## Problem

The `Upload coverage report to codecov.io` step is skipped on `push` runs to `main`, even in the main repository.

**Root cause:** The step condition references `github.event.pull_request.head.repo.full_name`, which is only available for `pull_request` events. On `push` events, this property is undefined, so the condition evaluates to false and the step is silently skipped.

Similarly, the fork coverage-threshold check runs with an undefined comparison on push events.

## Fix

- **Codecov upload step**: Add `github.event_name == 'push'` as an alternative condition, so uploads run on both push-to-main and same-repo PRs.
- **Fork threshold check**: Guard with `github.event_name == 'pull_request'` so it only runs for PRs (not pushes), avoiding undefined property access.

## Changes

2 lines changed in `.github/workflows/pytest-and-codecov.yml`:
- Upload step: `if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository`
- Threshold step: `if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository`

Fixes #892