### PR TITLE
docs: correct call to scanapi's run without scanapi.yaml file

### DIFF
--- a/wiki/Run-ScanAPI-Locally-Manually.md
+++ b/wiki/Run-ScanAPI-Locally-Manually.md
@@ -97,13 +97,13 @@ executes the requests, and validates the responses.
 If you try to run ScanAPI without a specification file:
 
 ```bash
-uv run scanapi
+uv run scanapi run
 ```
 
 You will see an error like:
 
-```bash
-ERROR:scanapi:Could not find API spec file: scanapi.yaml.
+```plaintext
+ERROR    Could not find API spec file: scanapi.yaml. [Errno 2] No such file or directory: 'scanapi.yaml'
 ```
 
 This happens because ScanAPI looks for a `scanapi.yaml` file by default.

--- a/wiki/Run-ScanAPI-Locally-with-Dev-Container.md
+++ b/wiki/Run-ScanAPI-Locally-with-Dev-Container.md
@@ -91,13 +91,13 @@ executes the requests, and validates the responses.
 If you try to run ScanAPI without a specification file:
 
 ```bash
-uv run scanapi
+uv run scanapi run
 ```
 
 You will see an error like:
 
-```bash
-ERROR:scanapi:Could not find API spec file: scanapi.yaml.
+```plaintext
+ERROR    Could not find API spec file: scanapi.yaml. [Errno 2] No such file or directory: 'scanapi.yaml'
 ```
 
 This happens because ScanAPI looks for a `scanapi.yaml` file by default.


### PR DESCRIPTION
## Description
The wiki has an incorrect command call/response text, which might confuse new adopters trying to run ScanAPI locally.

Before the wiki brought `uv run scanapi`, which doesn't trigger the "missing scanapi.yaml file" error because it's not calling the `run` from ScanAPI, only the `run` from `uv`. This can cause confusion, one example being issue #674 .

## What type of change is this?
Simple documentation change.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue

Discussion at https://github.com/scanapi/scanapi/issues/674#issuecomment-4319698905.
