### PR TITLE
docs(wiki): add Table of Contents to Run-ScanAPI-Locally-with-Dev-Container

### DIFF
--- a/wiki/Run-ScanAPI-Locally-with-Dev-Container.md
+++ b/wiki/Run-ScanAPI-Locally-with-Dev-Container.md
@@ -1,5 +1,18 @@
 # Run ScanAPI locally with Dev Container
 
+## Contents
+
+- [Dev Container setup](#dev-container-setup)
+- [1. Install requirements](#1-install-requirements)
+- [2. Clone your fork](#2-clone-your-fork)
+- [3. Open in Dev Container](#3-open-in-dev-container)
+- [4. Verify the environment](#4-verify-the-environment)
+  - [4.1 Check ScanAPI version](#41-check-scanapi-version)
+  - [4.2 Run project checks](#42-run-project-checks)
+- [5. Run your first scan](#5-run-your-first-scan)
+- [6. View the report](#6-view-the-report)
+- [7. Try another example](#7-try-another-example)
+
 > For the centralized comparison of all supported ScanAPI development environments, see [Run ScanAPI in Dev Env](Run-ScanAPI-in-Dev-Env.md).
 
 Running ScanAPI using a Dev Container is an alternative to manual setup.


### PR DESCRIPTION
## Description

Adds a Table of Contents to `wiki/Run-ScanAPI-Locally-with-Dev-Container.md` so readers can jump directly to any setup step or verification subsection. The TOC structure follows the example provided in the issue and matches the existing heading hierarchy.

## Motivation behind this PR?

Implements #884. The document is a detailed step-by-step guide that previously had no navigation, making it slow to skim or jump back to a specific section.

## What type of change is this?

Documentation only. No code or runtime behaviour affected.

## Checklist

- [x] A changelog entry was added, or this PR does not require one.
- [x] Unit tests were added or updated as needed, or not required for this change.
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required.
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project's style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary.

## Issue

Closes #884