### PR TITLE
docs: add pipx as an alternative install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ for each response and will receive a full real-time diagnostic report of the API
 $ pip install scanapi
 ```
 
+#### Install with pipx (isolated CLI)
+
+If `pip install scanapi` collides with the dependencies in your project's environment, install it with [pipx][pipx] instead. pipx gives ScanAPI its own virtual environment and still puts the `scanapi` command on your PATH:
+
+```bash
+$ pipx install scanapi
+```
+
+This is the recommended path when you want ScanAPI as a standalone CLI rather than a project dependency.
+
 ### Basic Usage
 
 You will need to write the API's specification and save it as a **YAML** or **JSON** file.
@@ -139,6 +149,7 @@ _Made with [contrib.rocks](https://contrib.rocks)._
 [github-issues]: https://github.com/scanapi/scanapi/issues
 [contribution-guide]: CONTRIBUTING.md
 [pip-installation]: https://pip.pypa.io/en/stable/installing/
+[pipx]: https://pipx.pypa.io/
 [scanapi-examples]: https://github.com/scanapi/examples
 [tutorial]: https://scanapi.dev/tutorials/step01
 [website]: https://scanapi.dev


### PR DESCRIPTION
Adds pipx as an alternative install path under the existing `pip install scanapi` block. Useful when ScanAPI's pinned deps conflict with other tools in the same environment.

Closes #889

## Description

Small README addition under "How to install".

## Motivation behind this PR?

Ran into `pip install scanapi` failures from pin collisions with Streamlit and Prefect in my own projects. `pipx install scanapi` fixed it. Worth documenting for anyone hitting the same thing.

## What type of change is this?

Docs only.

## Checklist

- [x] A changelog entry was added, or this PR does not require one.
- [x] Unit tests were added or updated as needed, or not required for this change.
- [x] All unit tests pass locally.
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required.
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project's style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary.

## Issue

Closes #889