### PR TITLE
docs: add table of contents to Run-ScanAPI-Locally-Manually.md

### DIFF
--- a/wiki/Run-ScanAPI-Locally-Manually.md
+++ b/wiki/Run-ScanAPI-Locally-Manually.md
@@ -18,6 +18,18 @@ At this point, it is expected that you already:
 * have a GitHub account
 * forked the repository
 
+[Local Setup](#local-setup)
+- [1. Install requirements](#1-install-requirements)
+- [2. Clone your fork](#2-clone-your-fork)
+- [3. Clone the examples repository](#3-clone-the-examples-repository)
+- [4. Install dependencies](#4-install-dependencies)
+- [5. Verify the environment](#5-verify-the-environment)
+- - [5.1 Check ScanAPI version](#51-check-scanapi-version)
+- - [5.2 Run project checks](#52-run-project-checks)
+- [6. Run your first scan](#6-run-your-first-scan)
+- [7. View the report](#7-view-the-report)
+- [8. Try another example](#8-try-another-example)
+
 ## Local Setup
 
 ## 1. Install requirements


### PR DESCRIPTION
## Description
Adding ToC to `wiki/Run-ScanAPI-Locally-Manually.md`.

## Motivation behind this PR?
Lack of a Table of Contents for `wiki/Run-ScanAPI-Locally-Manually.md` to improve wiki navigation.

## What type of change is this?
Documentation

## Checklist

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
Closes #885 
