### PR TITLE
chore: Release v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.13.0] - 2026-05-11
 ### Added
-- Allow variables to be used globally across endpoints [#265](https://github.com/scanapi/scanapi/issues/265)
+- Allow variables to be used globally across endpoints [#810](https://github.com/scanapi/scanapi/pull/810)
 
 - `from openapi` command: convert an OpenAPI document (JSON or YAML) into ScanAPI format. [#866](https://github.com/scanapi/scanapi/pull/866)
 
@@ -306,7 +308,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.12.0...HEAD
+[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.13.0...HEAD
+[2.13.0]: https://github.com/scanapi/scanapi/compare/v2.12.0...v2.13.0
 [2.12.0]: https://github.com/scanapi/scanapi/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/scanapi/scanapi/compare/v2.10.2...v2.11.0
 [2.10.2]: https://github.com/scanapi/scanapi/compare/v2.10.1...v2.10.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN python -m pip install --no-cache-dir pip==26.0.1 \
     setuptools==82.0.1 \
     --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
 
-RUN python -m pip install --no-cache-dir scanapi==2.12.0 \
-    --hash=sha256:5aa0e644c2037965c4c0c1db884bf4fc02078acb51c065700785de25557b5399
+RUN python -m pip install --no-cache-dir scanapi==2.13.0
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scanapi"
-version = "2.12.0"
+version = "2.13.0"
 description = "Automated Testing and Documentation for your REST API"
 authors = [{name = "The ScanAPI Organization", email = "cmaiacd@gmail.com"}]
 license = "MIT"

--- a/wiki/Deploy.md
+++ b/wiki/Deploy.md
@@ -31,7 +31,7 @@ And add the version links, like [this](https://github.com/scanapi/scanapi/commit
 
 ### Create the PR
 
-Create a PR named `Release <version>` containing these two changes above.
+Create a new branch called 'v<version-number>' and create a PR named `Release <version>` containing these two changes above.
 
 [Example of Release PR](https://github.com/scanapi/scanapi/commit/86e89e6ab52bbf64e058c02dbfdbbb1500066bff)
 


### PR DESCRIPTION
## [2.13.0] - 2026-05-11
### Added
- Allow variables to be used globally across endpoints [#810](https://github.com/scanapi/scanapi/pull/810)

- `from openapi` command: convert an OpenAPI document (JSON or YAML) into ScanAPI format. [#866](https://github.com/scanapi/scanapi/pull/866)

### Security
- Replace unsafe `eval()` with RestrictedPython to prevent arbitrary code execution in API spec evaluation. [#798](https://github.com/scanapi/scanapi/pull/798)