### PR TITLE
docs: 883: Add ToC to Run ScapAPI On Codespaces document

### DIFF
--- a/wiki/Run-ScanAPI-On-Codespaces.md
+++ b/wiki/Run-ScanAPI-On-Codespaces.md
@@ -178,7 +178,7 @@ uv run scanapi run ../examples/demo-api/scanapi.yaml \
 If something doesn’t work as expected, the steps below cover the most common issues
 and how to fix them. Use these commands to reset or repair your environment when needed.
 
-### Rebuild container
+### 8.1 Rebuild container
 
 If something is broken or outdated:
 
@@ -187,7 +187,7 @@ If something is broken or outdated:
 
 This recreates the environment from scratch.
 
-### Reinstall dependencies
+### 8.2 Reinstall dependencies
 
 If something seems inconsistent or broken:
 
@@ -197,7 +197,7 @@ uv pip install -e ".[dev]" --force-reinstall
 
 This reinstalls all project dependencies.
 
-### Fix pre-commit
+### 8.3 Fix pre-commit
 
 If hooks are not running:
 
@@ -207,7 +207,7 @@ uv run pre-commit install --install-hooks
 
 This ensures checks run automatically before commits.
 
-### Clear caches
+### 8.4 Clear caches
 
 If you see strange test or lint behavior:
 

--- a/wiki/Run-ScanAPI-On-Codespaces.md
+++ b/wiki/Run-ScanAPI-On-Codespaces.md
@@ -11,6 +11,25 @@ At this point, it is expected that you already:
 * have a GitHub account
 * forked the repository
 
+## Table of Contents (TOC)
+- [1. Open your fork in Codespaces](#1-open-your-fork-in-codespaces)
+- [2. Wait for setup to finish](#2-wait-for-setup-to-finish)
+- [3. Add the examples folder](#3-add-the-examples-folder)
+  - [3.1 Add the folder](#31-add-the-folder)
+  - [3.2 Save the workspace](#32-save-the-workspace)
+  - [3.3 Reopen later](#33-reopen-later)
+- [4. Verify the environment](#4-verify-the-environment)
+  - [4.1 Check ScanAPI is installed](#41-check-scanapi-is-installed)
+  - [4.2 Run project checks](#42-run-project-checks)
+- [5. Run your first scan](#5-run-your-first-scan)
+- [6. View the report (browser)](#6-view-the-report-browser)
+- [7. Try another example](#7-try-another-example)
+- [8. Troubleshooting](#8-troubleshooting)
+  - [8.1 Rebuild container](#81-rebuild-container)
+  - [8.2 Reinstall dependencies](#82-reinstall-dependencies)
+  - [8.3 Fix pre-commit](#83-fix-pre-commit)
+  - [8.4 Clear caches](#84-clear-caches)
+
 ## 1. Open your fork in Codespaces
 
 - Go to your fork (e.g. `https://github.com/<your-user>/scanapi`)


### PR DESCRIPTION
## Description
Documentation updates to `wiki/Run-ScanAPI-On-Codespaces.md`:
- Adds numbers to sub sections of section 8. Troubleshooting
- Adds Table of Contents to the top of document 
 
Verified by using Markdown viewer in VS Code and clicking on each link in the ToC and making sure it goes to the appropriate section.

## Motivation behind this PR?
This is just a documentation update as described in issues #883 

## What type of change is this?
Documentation update

## AI Assistance Disclosure (REQUIRED)
- [x] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
Closes #883 
