### PR TITLE
ci: Add close stale issues Github Actions workflow

### DIFF
--- a/.github/workflows/close-stale-issues-v1.yml
+++ b/.github/workflows/close-stale-issues-v1.yml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and PRs'
+
+on:
+  workflow_call:
+  schedule:
+    - cron: '00 4 * * *'
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
+env:
+  ISSUE_STALE_DAYS: '45'
+  PR_STALE_DAYS: '30'
+  ISSUE_CLOSE_DAYS: '60'
+  PR_CLOSE_DAYS: '45'
+
+jobs:
+  close_stale_issues:
+    name: Close stale issues and PRs
+    uses: cumbucadev/shared-workflows/.github/workflows/close-stale-issues-v1.yml@2535d1542434bda3afa064424a687f0c368db494


### PR DESCRIPTION
## Description
Adds close stale issues Github Action from [`cumbucadev/shared-workflows`](https://github.com/cumbucadev/shared-workflows) with default settings by linking to the last commit that modified it.

## Motivation behind this PR?
Helps keep the issue tracker organized and removes stale PRs making it easier to see what still needs work.

## What type of change is this?
Developer experience feature.

## AI Assistance Disclosure (REQUIRED)
- [x] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
Closes #893
