### PR TITLE
fix(rtd): update .readthedocs.yaml for RTD build compatibility

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,10 @@ build:
   image: latest
   os: ubuntu-22.04
   project_type: mkdocs
+  tools:
+    python: "3.14"
 
 python:
-  version: 3.14
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Description
Updated .readthedocs.yaml to include the required `build.tools` section and specify the Python version for ReadTheDocs v2. This makes the RTD build configuration compatible with the project’s MkDocs documentation setup.

## Motivation behind this PR?
The ReadTheDocs build was failing with:

> Missing configuration option At least one of the following configuration options is required: build.tools or build.commands.

<img width="976" height="614" alt="Image" src="https://github.com/user-attachments/assets/f9d4007a-00fb-46c7-a9f7-3702a8496d69" />

This change fixes the RTD build configuration so the docs can build successfully.

## What type of change is this?
- [x] Bug Fix

## AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [ x Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
Closes #925