### PR TITLE
feat: Modify time deltas in HTML report to be more human readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Update Generated at time, Total time delta, and response time delta in the HTML report to be more easily human readable
 
 ## [2.13.2] - 2026-05-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Update Generated at time, Total time delta, and response time delta in the HTML report to be more easily human readable
+- Update Total time delta and response time delta in the HTML report to be more easily human readable
 
 ## [2.13.2] - 2026-05-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
 - Update Total time delta and response time delta in the HTML report to be more easily human readable
 
 ## [2.13.2] - 2026-05-18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "rich>=14.2.0,<15.0.0",
     "PyYAML>=6.0.2,<7.0.0",
     "Jinja2>=3.1.0,<4.0.0",
+    "jinja2-humanize-extension>=0.4.0,<1.0.0",
     "click>=8.1.3,<9.0.0",
     "httpx>=0.27,<1.0.0",
     "packaging>=24,<26.0.0",

--- a/scanapi/template_render.py
+++ b/scanapi/template_render.py
@@ -5,7 +5,11 @@ from jinja2 import Environment, FileSystemLoader, PackageLoader
 def render(template_path, context, is_external=False):
     """Controller function that handles the Jinja2 rending of the template."""
     loader = _loader(is_external)
-    env = Environment(loader=loader, autoescape=True, extensions=["jinja2_humanize_extension.HumanizeExtension"])
+    env = Environment(
+        loader=loader,
+        autoescape=True,
+        extensions=["jinja2_humanize_extension.HumanizeExtension"],
+    )
     env.filters["curlify"] = curlify2.to_curl
     env.filters["render_body"] = render_body
     env.globals["is_bytes"] = lambda o: isinstance(o, bytes)

--- a/scanapi/template_render.py
+++ b/scanapi/template_render.py
@@ -5,7 +5,7 @@ from jinja2 import Environment, FileSystemLoader, PackageLoader
 def render(template_path, context, is_external=False):
     """Controller function that handles the Jinja2 rending of the template."""
     loader = _loader(is_external)
-    env = Environment(loader=loader, autoescape=True)
+    env = Environment(loader=loader, autoescape=True, extensions=["jinja2_humanize_extension.HumanizeExtension"])
     env.filters["curlify"] = curlify2.to_curl
     env.filters["render_body"] = render_body
     env.globals["is_bytes"] = lambda o: isinstance(o, bytes)

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -474,7 +474,7 @@
             {% else %}
             <h1 class="summary__title__name">Report generated for your API</h1>
             {% endif %}
-            <p class="summary__title__overview">Generated at: {{now|humanize_naturaltime()}}</p>
+            <p class="summary__title__overview">Generated at: {{now}}</p>
         </header>
 
         <!-- summary_box -->

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -474,7 +474,7 @@
             {% else %}
             <h1 class="summary__title__name">Report generated for your API</h1>
             {% endif %}
-            <p class="summary__title__overview">Generated at: {{now}}</p>
+            <p class="summary__title__overview">Generated at: {{now|humanize_naturaltime()}}</p>
         </header>
 
         <!-- summary_box -->
@@ -568,7 +568,7 @@
                                         response time
                                     </td>
                                     <td class="wordbreak">
-                                        {{ response.elapsed.total_seconds() }} s
+                                        {{ response.elapsed.total_seconds()|humanize_precisedelta() }}
                                     </td>
                                 </tr>
                                 <tr>
@@ -656,7 +656,7 @@
                 <span><strong>PASSED:</strong> {{session.successes}}</span>
                 <span><strong>FAILURES:</strong> {{session.failures}}</span>
                 <span><strong>ERRORS:</strong> {{session.errors}}</span>
-                <span><strong>Total Time:</strong> {{ session.elapsed_time() }}</span>
+                <span><strong>Total Time:</strong> {{ session.elapsed_time()|humanize_precisedelta() }}</span>
             </div>
         </div>
     </div>

--- a/uv.lock
+++ b/uv.lock
@@ -458,6 +458,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.13"
 source = { registry = "https://pypi.org/simple" }
@@ -494,6 +503,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jinja2-humanize-extension"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanize" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/77/0bba383819dd4e67566487c11c49479ced87e77c3285d8e7f7a3401cf882/jinja2_humanize_extension-0.4.0.tar.gz", hash = "sha256:e7d69b1c20f32815bbec722330ee8af14b1287bb1c2b0afa590dbf031cadeaa0", size = 4746, upload-time = "2023-09-01T12:52:42.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/b4/08c9d297edd5e1182506edecccbb88a92e1122a057953068cadac420ca5d/jinja2_humanize_extension-0.4.0-py3-none-any.whl", hash = "sha256:b6326e2da0f7d425338bebf58848e830421defbce785f12ae812e65128518156", size = 4769, upload-time = "2023-09-01T12:52:41.098Z" },
 ]
 
 [[package]]
@@ -1640,6 +1662,7 @@ dependencies = [
     { name = "curlify2" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "jinja2-humanize-extension" },
     { name = "markupsafe" },
     { name = "openapi-spec-validator" },
     { name = "packaging" },
@@ -1678,6 +1701,7 @@ requires-dist = [
     { name = "curlify2", specifier = ">=1.0.1,<2.0.0" },
     { name = "httpx", specifier = ">=0.27,<1.0.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0.0" },
+    { name = "jinja2-humanize-extension", specifier = ">=0.4.0,<1.0.0" },
     { name = "markupsafe", specifier = ">=2.1,<4.0" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.4.2,<2.0.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.1.0,<10.0.0" },


### PR DESCRIPTION
## Description
Adds `jinja2-humanize-extension` extension and uses it to make ~`Generated at`,~ `Total time`~,~ and `response time` in the HTML report more readable via ~`naturaltime` and~ `precisedelta`. I chose not to use `naturaldelta` as it was a little too "natural" (as can be seen in the last screenshot). I also chose not to humanize the `date` in the header or other time references as I figured it is better to not modify the headers as much as possible, but I am open to changing the header data display as well. 🙂 

A new unreleased entry to the changelog was also added as this modifies the UI.

### Screenshots
#### Before
<img width="1317" height="534" alt="Screenshot 2026-05-18 at 3 36 14 PM" src="https://github.com/user-attachments/assets/25bda2fb-af5f-4770-b5ed-79424742754e" />

#### After
<img width="1226" height="490" alt="Screenshot 2026-05-18 at 5 21 39 PM" src="https://github.com/user-attachments/assets/df82ba2f-f3a9-4d64-be83-0564a10c9dd1" />

<img width="1338" height="618" alt="Screenshot 2026-05-18 at 3 47 46 PM" src="https://github.com/user-attachments/assets/e566e2f1-59db-48ad-82fe-fd2814ba1715" />

#### Unused alternative (`naturaldelta`)
<img width="1346" height="538" alt="Screenshot 2026-05-18 at 3 37 20 PM" src="https://github.com/user-attachments/assets/6a17446b-7ecd-4640-a6db-bcf459412ee4" />

## Motivation behind this PR?
To make most used time related fields in the report much easier to read for humans.

## What type of change is this?
Feature

## AI Assistance Disclosure (REQUIRED)
- [x] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [x] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
Closes #897 
