### PR TITLE
fix(rtd): replace project_type with MkDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,12 @@
 version: 2
 
 build:
-  image: latest
   os: ubuntu-22.04
-  project_type: mkdocs
   tools:
     python: "3.14"
+
+mkdocs:
+  configuration: mkdocs.yml
 
 python:
   install:


### PR DESCRIPTION
## Description

Updates the Read the Docs configuration after migrating the documentation from Sphinx to MkDocs. This PR replaces the deprecated `project_type: mkdocs` approach with the explicit `mkdocs.configuration` setting required by RTD.

## Motivation behind this PR?

RTD was still attempting to build the project as a Sphinx project and failing with:

```text
Missing Sphinx configuration key

The sphinx.configuration key is missing.
```

This change ensures RTD correctly recognizes and builds the project using MkDocs.

## What type of change is this?

Bug Fix

## AI Assistance Disclosure (REQUIRED)

* [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist

* [x] A changelog entry was added, or this PR does not require one.
* [x] Unit tests were added or updated as needed, or not required for this change.
* [ ] All unit tests pass locally.
* [x] Docstrings or comments were added or updated as needed, or no documentation changes were required.
* [x] This PR does not significantly reduce code or docstring coverage.
* [x] Code follows the project’s style guidelines.
* [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary.

## Issue

Closes #928
