### PR TITLE
docs: configure mkdocstrings Google docstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ plugins:
           setup_commands:
             - "import sys, os; sys.path.insert(0, os.path.abspath('.'))"
           options:
+            docstring_style: google
             show_root_toc: true
   - autorefs
 theme:


### PR DESCRIPTION
Closes #931.

## Summary
- set mkdocstrings Python handler to parse Google-style docstrings explicitly

## Checks
- git diff --check

Note: attempted uv run --extra dev mkdocs build --strict, but dependency setup/build did not finish within the local timeout.