### PR TITLE
docs: fix docstring formatting to follow Google style

### DIFF
--- a/scanapi/console.py
+++ b/scanapi/console.py
@@ -10,7 +10,8 @@ def write_results(results):
     """Print the test results to the console output
 
     Returns:
-        None
+        None: This function does not return a value. It prints directly
+            to the console output.
     """
     for r in results:
         write_result(r)
@@ -20,7 +21,8 @@ def write_result(result):
     """Print the test result to the console output
 
     Returns:
-        None
+        None: This function does not return a value. It prints directly
+            to the console output.
     """
     for test in result["tests_results"]:
         if test["status"] is TestStatus.PASSED:
@@ -36,7 +38,8 @@ def write_report_path(uri):
     """Print path to generated documentation
 
     Returns:
-        None
+        None: This function does not return a value. It prints the success
+            message and the documentation link directly to the console output.
     """
     console.print(
         f"The documentation was generated successfully.\n"
@@ -48,7 +51,8 @@ def write_summary():
     """Write tests summary in console
 
     Returns:
-        None
+        None: None: This function does not return a value. It prints the execution
+            time and test results summary directly to the console output.
     """
     elapsed_time = round(session.elapsed_time().total_seconds(), 2)
 
@@ -63,7 +67,8 @@ def _print_summary_with_failures_or_errors(elapsed_time):
     """Write tests summary when there are failures or errors
 
     Returns:
-        None
+        None: This function does not return a value. It prints the detailed
+            failure and error counts directly to the console output.
     """
     summary = (
         f"[bright_green]{session.successes} passed, "
@@ -79,7 +84,8 @@ def _print_successful_summary(elapsed_time):
     """Write tests summary when there are no failures or errors
 
     Returns:
-        None
+        None: This function does not return a value. It prints the successful
+            test results summary directly to the console output.
     """
     console.line()
     console.rule(

--- a/scanapi/console.py
+++ b/scanapi/console.py
@@ -51,7 +51,7 @@ def write_summary():
     """Write tests summary in console
 
     Returns:
-        None: None: This function does not return a value. It prints the execution
+        None: This function does not return a value. It prints the execution
             time and test results summary directly to the console output.
     """
     elapsed_time = round(session.elapsed_time().total_seconds(), 2)

--- a/scanapi/convert.py
+++ b/scanapi/convert.py
@@ -20,7 +20,8 @@ def openapi_to_scanapi():
     and parsing the OpenAPI schema.
 
     Returns:
-        None
+        None: This function does not return a value. It executes the
+            specification conversion and writes the resulting report.
     """
     openapi_path = settings["input_path"]
     base_url = settings["base_url"]

--- a/scanapi/converters/from_openapi.py
+++ b/scanapi/converters/from_openapi.py
@@ -118,8 +118,9 @@ class OpenAPIToScanAPIConverter:
         Formats required properties for a given request body schema as a dictionary.
 
         Returns:
-            dict|None: Keys are property names and values are custom variables created
-            using the operation_id and the property name.
+            dict|None: Keys are property names and values are custom
+            variables created using the operation_id and the
+            property name.
         """
         required_properties = None
         if "required" in schema:

--- a/scanapi/converters/from_openapi.py
+++ b/scanapi/converters/from_openapi.py
@@ -5,7 +5,7 @@ class OpenAPIToScanAPIConverter:
     and authentication schema.
 
     Attributes:
-        specs[dict]: Dictionary parsed from the OpenAPI schema.
+        specs (dict): Dictionary parsed from the OpenAPI schema.
     """
 
     SECURITY_SCHEME_TYPES = ("http", "oauth2", "bearer")
@@ -33,10 +33,10 @@ class OpenAPIToScanAPIConverter:
         """Reads the version from parsed specification
 
         Returns:
-            [str]: version string
+            str: version string
 
         Raises:
-            [ValueError]: Couldn't find version key on parsed specification
+            ValueError: Couldn't find version key on parsed specification
         """
         spec_version: str | None = None
         if "openapi" in self.specs:
@@ -57,7 +57,7 @@ class OpenAPIToScanAPIConverter:
             None
 
         Raises:
-            [ValueError]: Unsupported OpenAPI specification version
+            ValueError: Unsupported OpenAPI specification version
         """
         specs_version = self._get_spec_version()
         print(f"OpenAPI/Swagger version detected: {specs_version}\n")
@@ -71,7 +71,7 @@ class OpenAPIToScanAPIConverter:
         """Reads title from the spec info tag.
 
         Returns:
-            [str|None]: Title if present, otherwise None
+            str | None: Title if present, otherwise None
         """
         info = self.specs.get("info", None)
         if info is None:
@@ -88,7 +88,7 @@ class OpenAPIToScanAPIConverter:
         Reference: <https://swagger.io/docs/specification/v3_0/authentication/#describing-security>
 
         Returns:
-            [list[dict]]: name and type of found security schemes.
+            list[dict]: name and type of found security schemes.
         """
         security_schemes = []
         if (
@@ -118,7 +118,7 @@ class OpenAPIToScanAPIConverter:
         Formats required properties for a given request body schema as a dictionary.
 
         Returns:
-            [dict|None]: Keys are property names and values are custom variables created using the operation_id and the property name.
+            dict|None: Keys are property names and values are custom variables created using the operation_id and the property name.
         """
         required_properties = None
         if "required" in schema:
@@ -154,7 +154,7 @@ class OpenAPIToScanAPIConverter:
         with a defined request body.
 
         Returns:
-            [dict|None]: Keys are property names and values are custom variables created using the operation_id and the property name.
+            dict|None: Keys are property names and values are custom variables created using the operation_id and the property name.
         """
         api_target_body = None
         content = operation["requestBody"]["content"]
@@ -177,7 +177,7 @@ class OpenAPIToScanAPIConverter:
         :param base_url: Base URL for the API
 
         Returns:
-            [tuple]: converted YAML dictionary and set of created variables
+            tuple: converted YAML dictionary and set of created variables
         """
         base_yaml: dict = {
             "endpoints": [{"name": None, "path": base_url, "requests": []}]
@@ -253,7 +253,7 @@ def get_api_target_name(operation: dict, path: str, method: str) -> str:
     Changes all slashes and spaces to underscores.
 
     Returns:
-        [str]: generated target name
+        str: generated target name
     """
     return (
         str(
@@ -272,7 +272,7 @@ def get_required_params(operation: dict) -> list:
     parameters are always required (see https://swagger.io/docs/specification/v3_0/describing-parameters/#path-parameters).
 
     Returns:
-        [list[dict]]: Parameter name and location (in)
+        list[dict]: Parameter name and location (in)
     """
     params = []
     if "parameters" in operation:
@@ -296,7 +296,7 @@ def get_tests(operation: dict) -> list:
     Focuses on successful responses for minimal smoke testing.
 
     Returns:
-        [list[dict]]: Test name and assertion
+        list[dict]: Test name and assertion
     """
     tests = []
     if "responses" in operation:

--- a/scanapi/converters/from_openapi.py
+++ b/scanapi/converters/from_openapi.py
@@ -118,7 +118,8 @@ class OpenAPIToScanAPIConverter:
         Formats required properties for a given request body schema as a dictionary.
 
         Returns:
-            dict|None: Keys are property names and values are custom variables created using the operation_id and the property name.
+            dict|None: Keys are property names and values are custom variables created using the
+            operation_id and the property name.
         """
         required_properties = None
         if "required" in schema:
@@ -154,7 +155,10 @@ class OpenAPIToScanAPIConverter:
         with a defined request body.
 
         Returns:
-            dict|None: Keys are property names and values are custom variables created using the operation_id and the property name.
+            dict|None: Keys are property names and values are custom
+                variables created using the operation_id and the
+                property name.
+
         """
         api_target_body = None
         content = operation["requestBody"]["content"]

--- a/scanapi/converters/from_openapi.py
+++ b/scanapi/converters/from_openapi.py
@@ -118,8 +118,8 @@ class OpenAPIToScanAPIConverter:
         Formats required properties for a given request body schema as a dictionary.
 
         Returns:
-            dict|None: Keys are property names and values are custom variables created using the
-            operation_id and the property name.
+            dict|None: Keys are property names and values are custom variables created
+            using the operation_id and the property name.
         """
         required_properties = None
         if "required" in schema:

--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -28,7 +28,7 @@ class CodeEvaluator:
         Args:
             sequence (string): sequence of characters to be evaluated
             spec_vars (dict): dictionary containing the SpecEvaluator variables
-            is_a_test_case (bool): indicator for checking if the given 
+            is_a_test_case (bool): indicator for checking if the given
             evaluation is a test case
 
         Returns:

--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -26,15 +26,15 @@ class CodeEvaluator:
         present on it
 
         Args:
-            sequence[string]: sequence of characters to be evaluated
-            spec_vars[dict]: dictionary containing the SpecEvaluator variables
-            is_a_test_case[bool]: indicator for checking if the given evaluation
+            sequence (string): sequence of characters to be evaluated
+            spec_vars (dict): dictionary containing the SpecEvaluator variables
+            is_a_test_case (bool): indicator for checking if the given evaluation
             is a test case
 
         Returns:
             tuple: a tuple containing:
-                -  [Boolean]: True if python statement is valid
-                -  [string]: None if valid evaluation, tested code otherwise
+                -  Boolean: True if python statement is valid
+                -  string: None if valid evaluation, tested code otherwise
 
         Raises:
             InvalidPythonCodeError: If receives invalid python statements
@@ -108,8 +108,8 @@ class CodeEvaluator:
         """Safely evaluate Python code using RestrictedPython with mode='eval'.
 
         Args:
-            code[string]: Python code to evaluate
-            global_context[dict]: Global context for evaluation
+            code (string): Python code to evaluate
+            global_context (dict): Global context for evaluation
 
         Returns:
             Result of code evaluation
@@ -156,15 +156,15 @@ class CodeEvaluator:
         comprehensions using RestrictedPython for security.
 
         Args:
-            code[string]: python code that ScanAPI needs to assert
-            response[requests.Response]: the response for the current request
+            code (string): python code that ScanAPI needs to assert
+            response (requests.Response): the response for the current request
             that is being tested
 
         Returns:
             tuple: a tuple containing:
-                -  [Boolean]: a boolean that indicates if assert
+                -  Boolean: a boolean that indicates if assert
                 is True/False
-                -  [string]: None if valid evaluation, code tested otherwise
+                -  string: None if valid evaluation, code tested otherwise
 
         Raises:
             AssertionError: If python statement evaluates False

--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -28,8 +28,8 @@ class CodeEvaluator:
         Args:
             sequence (string): sequence of characters to be evaluated
             spec_vars (dict): dictionary containing the SpecEvaluator variables
-            is_a_test_case (bool): indicator for checking if the given evaluation
-            is a test case
+            is_a_test_case (bool): 
+                indicator for checking if the given evaluation is a test case
 
         Returns:
             tuple: a tuple containing:

--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -28,8 +28,8 @@ class CodeEvaluator:
         Args:
             sequence (string): sequence of characters to be evaluated
             spec_vars (dict): dictionary containing the SpecEvaluator variables
-            is_a_test_case (bool): 
-                indicator for checking if the given evaluation is a test case
+            is_a_test_case (bool): indicator for checking if the given 
+            evaluation is a test case
 
         Returns:
             tuple: a tuple containing:

--- a/scanapi/evaluators/spec_evaluator.py
+++ b/scanapi/evaluators/spec_evaluator.py
@@ -16,12 +16,12 @@ class SpecEvaluator:
         """Initialize a SpecEvaluator.
 
         Args:
-            endpoint (EndpointNode): Endpoint instance for which the spec 
+            endpoint (EndpointNode): Endpoint instance for which the spec
             is being evaluated.
             spec_vars (dict): Variables defined in the ScanAPI specification.
-            extras (dict, optional): Optional extra variables to include in 
+            extras (dict, optional): Optional extra variables to include in
             the registry.
-            filter_responses (bool): Whether to filter out response-related 
+            filter_responses (bool): Whether to filter out response-related
             variables.
 
         """
@@ -60,9 +60,9 @@ class SpecEvaluator:
         Args:
             spec_vars (dict): Mapping of spec variable names to
             expressions/values.
-            extras (dict, optional): Optional extra variables to 
+            extras (dict, optional): Optional extra variables to
             include in the registry.
-            filter_responses (bool): Whether to filter out response-related 
+            filter_responses (bool): Whether to filter out response-related
             variables.
         """
         if extras is None:

--- a/scanapi/evaluators/spec_evaluator.py
+++ b/scanapi/evaluators/spec_evaluator.py
@@ -16,10 +16,11 @@ class SpecEvaluator:
         """Initialize a SpecEvaluator.
 
         Args:
-            endpoint: Endpoint instance for which the spec is being evaluated.
-            spec_vars: Variables defined in the ScanAPI specification.
-            extras: Optional extra variables to include in the registry.
-            filter_responses: Whether to filter out response-related variables.
+            endpoint (EndpointNode): Endpoint instance for which the spec is being evaluated.
+            spec_vars (dict): Variables defined in the ScanAPI specification.
+            extras (dict, optional): Optional extra variables to include in the registry.
+            filter_responses (bool): Whether to filter out response-related variables.
+
         """
         self.endpoint = endpoint
         self.registry = {}
@@ -29,10 +30,10 @@ class SpecEvaluator:
         """Evaluate a spec element.
 
         Args:
-            element: Spec element/expression to evaluate.
+            element (Any): Spec element/expression to evaluate.
 
         Returns:
-            The evaluated value of the element.
+            Any: The evaluated value of the element.
         """
         return evaluate(element, self)
 
@@ -40,10 +41,10 @@ class SpecEvaluator:
         """Evaluate an assertion element.
 
         Args:
-            element: Assertion expression from a test case.
+            element (Any): Assertion expression from a test case.
 
         Returns:
-            Result of the evaluated assertion.
+            Any: Result of the evaluated assertion.
         """
         return _evaluate_str(element, self, is_a_test_case=True)
 
@@ -54,9 +55,9 @@ class SpecEvaluator:
         `extras` during evaluation) and updates the internal registry.
 
         Args:
-            spec_vars: Mapping of spec variable names to expressions/values.
-            extras: Optional extra variables to include in the registry.
-            filter_responses: Whether to filter out response-related variables.
+            spec_vars (dict): Mapping of spec variable names to expressions/values.
+            extras (dict, optional): Optional extra variables to include in the registry.
+            filter_responses (bool): Whether to filter out response-related variables.
         """
         if extras is None:
             extras = {}
@@ -74,13 +75,14 @@ class SpecEvaluator:
         """Retrieve a value from the registry.
 
         Args:
-            key: Name of the variable to retrieve.
-            default: Value to return if the key does not exist.
+            key (str): Name of the variable to retrieve.
+            default (Any): Value to return if the key does not exist.
 
         Returns:
-            Value associated with the given key or
+            Any: Value associated with the given key or
             `default` if key is not present.
         """
+
         try:
             return self[key]
         except KeyError:
@@ -94,14 +96,15 @@ class SpecEvaluator:
         """Retrieve a variable value from the registry.
 
         Args:
-            key: Variable name to retrieve.
+            key (str): Variable name to retrieve.
 
         Returns:
-            Value for the given key.
+            Any: Value for the given key.
 
         Raises:
             KeyError: If the key is not present in the registry or
             endpoint variables.
+        
         """
         if key in self:
             return self.registry[key]
@@ -116,7 +119,7 @@ class SpecEvaluator:
         """Delete a variable from the registry.
 
         Args:
-            key: Variable name to delete.
+            key (str): Variable name to delete.
 
         Raises:
             KeyError: If the key is not present in the registry.
@@ -130,10 +133,10 @@ class SpecEvaluator:
         """Check whether a variable exists in the registry.
 
         Args:
-            key: Variable name.
+            key (str): Variable name.
 
         Returns:
-            True if the variable exists in the registry, otherwise False.
+            bool: True if the variable exists in the registry, otherwise False.
         """
         return key in self.registry
 

--- a/scanapi/evaluators/spec_evaluator.py
+++ b/scanapi/evaluators/spec_evaluator.py
@@ -141,7 +141,7 @@ class SpecEvaluator:
         """Returns a copy of the dictionary's list of keys.
 
         Returns:
-            [list]: list of keys.
+            list: list of keys.
         """
         return self.registry.keys()
 
@@ -152,7 +152,7 @@ class SpecEvaluator:
         Any items with a ``response.*`` reference in their value are left out.
 
         Returns:
-            [dict]: filtered dictionary.
+            dict: filtered dictionary.
 
         """
         pattern = re.compile(r"(?:(\s*response\.\w+))")

--- a/scanapi/evaluators/spec_evaluator.py
+++ b/scanapi/evaluators/spec_evaluator.py
@@ -16,10 +16,13 @@ class SpecEvaluator:
         """Initialize a SpecEvaluator.
 
         Args:
-            endpoint (EndpointNode): Endpoint instance for which the spec is being evaluated.
+            endpoint (EndpointNode): Endpoint instance for which the spec 
+            is being evaluated.
             spec_vars (dict): Variables defined in the ScanAPI specification.
-            extras (dict, optional): Optional extra variables to include in the registry.
-            filter_responses (bool): Whether to filter out response-related variables.
+            extras (dict, optional): Optional extra variables to include in 
+            the registry.
+            filter_responses (bool): Whether to filter out response-related 
+            variables.
 
         """
         self.endpoint = endpoint
@@ -55,9 +58,12 @@ class SpecEvaluator:
         `extras` during evaluation) and updates the internal registry.
 
         Args:
-            spec_vars (dict): Mapping of spec variable names to expressions/values.
-            extras (dict, optional): Optional extra variables to include in the registry.
-            filter_responses (bool): Whether to filter out response-related variables.
+            spec_vars (dict): Mapping of spec variable names to
+            expressions/values.
+            extras (dict, optional): Optional extra variables to 
+            include in the registry.
+            filter_responses (bool): Whether to filter out response-related 
+            variables.
         """
         if extras is None:
             extras = {}
@@ -82,7 +88,6 @@ class SpecEvaluator:
             Any: Value associated with the given key or
             `default` if key is not present.
         """
-
         try:
             return self[key]
         except KeyError:
@@ -104,7 +109,6 @@ class SpecEvaluator:
         Raises:
             KeyError: If the key is not present in the registry or
             endpoint variables.
-        
         """
         if key in self:
             return self.registry[key]

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -26,15 +26,15 @@ class StringEvaluator:
         environment variables present on it
 
         Args:
-            sequence[string]: sequence of characters to be evaluated
-            spec_vars[dict]: dictionary containing the SpecEvaluator variables
-            is_a_test_case[bool]: indicator for checking if the given evaluation
+            sequence (string): sequence of characters to be evaluated
+            spec_vars (dict): dictionary containing the SpecEvaluator variables
+            is_a_test_case (bool): indicator for checking if the given evaluation
             is a test case
 
         Returns:
             tuple: a tuple containing:
-                -  [Boolean]: True if python statement is valid
-                -  [string]: None if valid evaluation, tested code otherwise
+                -  Boolean: True if python statement is valid
+                -  string: None if valid evaluation, tested code otherwise
 
         """
         sequence = cls._evaluate_env_var(sequence)
@@ -48,10 +48,10 @@ class StringEvaluator:
         variables present on it
 
         Args:
-            sequence[string]: sequence of characters to be evaluated
+            sequence (string): sequence of characters to be evaluated
 
         Returns:
-            sequence[string]: sequence of characters with all valid
+            sequence (string): sequence of characters with all valid
             environment variables replaced
         """
         matches = cls.variable_pattern.finditer(sequence)
@@ -79,11 +79,11 @@ class StringEvaluator:
         variables present on it
 
         Args:
-            sequence[string]: sequence of characters to be evaluated
-            spec_vars[dict]: dictionary containing the SpecEvaluator variables
+            sequence (string): sequence of characters to be evaluated
+            spec_vars (dict): dictionary containing the SpecEvaluator variables
 
         Returns:
-            sequence[string]: sequence of characters with all valid
+            sequence (string): sequence of characters with all valid
             custom variables replaced
         """
         matches = cls.variable_pattern.finditer(sequence)
@@ -111,12 +111,12 @@ class StringEvaluator:
         of a variable with its value
 
         Args:
-            sequence[string]: sequence of characters to be evaluated
-            variable[string]: variable to be replaced
-            variable_value[any]: value that will replace the variable
+            sequence (string): sequence of characters to be evaluated
+            variable (string): variable to be replaced
+            variable_value (any): value that will replace the variable
 
         Returns:
-            sequence[string]: sequence of characters with all occurrences of
+            sequence (string): sequence of characters with all occurrences of
             the current variable replaced
         """
         if variable == sequence:

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -28,8 +28,8 @@ class StringEvaluator:
         Args:
             sequence (string): sequence of characters to be evaluated
             spec_vars (dict): dictionary containing the SpecEvaluator variables
-            is_a_test_case (bool): indicator for checking if the given 
-            evaluation is a test case
+            is_a_test_case (bool): indicator for checking if the given
+            evaluation is a test case.
 
         Returns:
             tuple: a tuple containing:

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -28,8 +28,8 @@ class StringEvaluator:
         Args:
             sequence (string): sequence of characters to be evaluated
             spec_vars (dict): dictionary containing the SpecEvaluator variables
-            is_a_test_case (bool): indicator for checking if the given evaluation
-            is a test case
+            is_a_test_case (bool): 
+                indicator for checking if the given evaluation is a test case
 
         Returns:
             tuple: a tuple containing:

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -28,8 +28,8 @@ class StringEvaluator:
         Args:
             sequence (string): sequence of characters to be evaluated
             spec_vars (dict): dictionary containing the SpecEvaluator variables
-            is_a_test_case (bool): 
-                indicator for checking if the given evaluation is a test case
+            is_a_test_case (bool): indicator for checking if the given 
+            evaluation is a test case
 
         Returns:
             tuple: a tuple containing:

--- a/scanapi/hide_utils.py
+++ b/scanapi/hide_utils.py
@@ -17,7 +17,7 @@ def hide_sensitive_info(response):
     string `SENSITIVE_INFORMATION`.
 
     Args:
-        response [requests.models.Response]: the response that has
+        response (requests.models.Response): the response that has
         information to be hidden.
 
     """
@@ -35,9 +35,9 @@ def _hide(http_msg, hide_settings):
     _override_info to have sensitive data replaced.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        hide_settings [dic]: the fields that need to be hidden for each http
+        hide_settings (dict): the fields that need to be hidden for each http
         attribute (body, headers, url params)
 
     """
@@ -52,11 +52,11 @@ def _override_info(http_msg, http_attr, secret_field):
     'SENSITIVE_INFORMATION'.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        http_attr [string]: the http_attr that has a field to be hidden: body,
+        http_attr (string): the http_attr that has a field to be hidden: body,
         headers, url or params
-        secret_field [string]: the secret field which its value must be hidden.
+        secret_field (string): the secret field which its value must be hidden.
 
     """
     if http_attr == URL:
@@ -74,9 +74,9 @@ def _override_url(http_msg, secret_field):
     'SENSITIVE_INFORMATION' in URLs.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        secret_field [string]: the secret field which its value must be hidden
+        secret_field (string): the secret field which its value must be hidden
         in the URL.
 
     """
@@ -96,9 +96,9 @@ def _override_headers(http_msg, secret_field):
     'SENSITIVE_INFORMATION' in the request/response headers.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        secret_field [string]: the secret field which its value must be hidden
+        secret_field (string): the secret field which its value must be hidden
         in the request/response headers.
 
     """
@@ -111,9 +111,9 @@ def _override_params(http_msg, secret_field):
     'SENSITIVE_INFORMATION' in the request/response params.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        secret_field [string]: the secret field which its value must be hidden
+        secret_field (string): the secret field which its value must be hidden
         in the request/response params.
 
     """
@@ -139,9 +139,9 @@ def _override_body(http_msg, secret_field):
     'SENSITIVE_INFORMATION' in the request/response body/content.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        secret_field [string]: the secret field which its value must be hidden
+        secret_field (string): the secret field which its value must be hidden
         in the request/response body/content.
 
     """
@@ -156,11 +156,11 @@ def _get_json_body(http_msg):
     """Private method that gets the json body/content of a request/response.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
 
     Returns:
-        [dict]: the json body/content of the request/response.
+        dict: the json body/content of the request/response.
 
     """
     try:
@@ -179,11 +179,11 @@ def _get_body(http_msg):
     """Private method that gets the body/content of a request/response.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
 
     Returns:
-        [bytes]: the body/content of the request/response.
+        bytes: the body/content of the request/response.
     """
     if not hasattr(http_msg, "body"):
         return http_msg._content
@@ -195,9 +195,9 @@ def _set_json_body(http_msg, value):
     """Private method that sets the json body/content of a request/response.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        value [dict]: the json body/content of the request/response.
+        value (dict): the json body/content of the request/response.
 
     """
     value = json.dumps(value).encode("utf-8")
@@ -208,9 +208,9 @@ def _set_body(http_msg, value):
     """Private method that sets the body/content of a request/response.
 
     Args:
-        http_msg [requests.models.PreparedRequest / requests.models.Response]:
+        http_msg (requests.models.PreparedRequest / requests.models.Response):
         the request or the response that has information to be hidden.
-        value [bytes]: the body/content of the request/response.
+        value (bytes): the body/content of the request/response.
 
     """
     if not hasattr(http_msg, "body"):

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -15,8 +15,8 @@ class Reporter:
     """Class that writes the scan report
 
     Attributes:
-        output_path[str, optional]: Report output path
-        template[str, optional]: Custom report template path
+        output_path (str, optional): Report output path
+        template (str, optional): Custom report template path
 
     """
 
@@ -30,7 +30,7 @@ class Reporter:
         scanapi-report.html.
 
         Args:
-            results [generator]: generator of dicts resulting of Request run().
+            results (generator): generator of dicts resulting of Request run().
 
         Returns:
             None
@@ -59,10 +59,10 @@ class Reporter:
         """Build context dict of values required to render template.
 
         Args:
-            results [generator]: generator of dicts resulting of Request run().
+            results (generator): generator of dicts resulting of Request run().
 
         Returns:
-            [dict]: values required to render template.
+            dict: values required to render template.
 
         """
         try:

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -33,7 +33,8 @@ class Reporter:
             results (generator): generator of dicts resulting of Request run().
 
         Returns:
-            None
+            None: This function does not return a value. It creates and writes
+              the 'scanapi-report.html' file with the test results.
 
         """
         template_path = self.template if self.template else "report.html"

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -34,10 +34,10 @@ class EndpointNode:
     where each EndpointNode may contain multiple children EndpointNodes.
 
     Attributes:
-        spec[dict]: dictionary containing the endpoint's specifications
-        parent[EndpointNode, optional]: the parent node
-        child_nodes[list of EndpointNodes]: the children nodes
-        spec_vars[SpecEvaluator]: evaluator used to evaluate expressions
+        spec (dict): dictionary containing the endpoint's specifications
+        parent (EndpointNode, optional): the parent node
+        child_nodes (list of EndpointNodes): the children nodes
+        spec_vars (SpecEvaluator): evaluator used to evaluate expressions
                                   and store spec variables
     """
 
@@ -87,7 +87,7 @@ class EndpointNode:
         if it is not a root node.
 
         Returns:
-            [str]: The endpoint's name.
+            str: The endpoint's name.
         """
         name = self.spec.get(NAME_KEY, "")
 
@@ -103,7 +103,7 @@ class EndpointNode:
         evaluated.
 
         Returns:
-            [str]: The endpoint's url.
+            str: The endpoint's url.
         """
         path = str(self.spec.get(PATH_KEY, "")).strip()
         url = join_urls(self.parent.path, path) if self.parent else path
@@ -116,7 +116,7 @@ class EndpointNode:
         The options of the call include the parent's options.
 
         Returns:
-            [dict]: the keyword used in the endpoint call.
+            dict: the keyword used in the endpoint call.
         """
         options = self._get_specs(OPTIONS_KEY)
         for option in options:
@@ -131,7 +131,7 @@ class EndpointNode:
         call include the parent's headers.
 
         Returns:
-            [dict]: the headers used in the endpoint call.
+            dict: the headers used in the endpoint call.
         """
         return self._get_specs(HEADERS_KEY)
 
@@ -141,7 +141,7 @@ class EndpointNode:
         call include the parent's parameters.
 
         Returns:
-            [dict]: the parameters used in the endpoint call.
+            (dict): the parameters used in the endpoint call.
         """
         return self._get_specs(PARAMS_KEY)
 
@@ -151,7 +151,7 @@ class EndpointNode:
         call.
 
         Returns:
-            [int]: the time to be waited.
+            int: the time to be waited.
         """
         delay = self.spec.get(DELAY_KEY, 0)
         return delay or getattr(self.parent, DELAY_KEY, 0)
@@ -161,7 +161,7 @@ class EndpointNode:
         """Check if the EndpointNode is a root node.
 
         Returns:
-            [bool]: true if the node has no parent, false otherwise.
+            bool: true if the node has no parent, false otherwise.
         """
         return not self.parent
 
@@ -174,8 +174,8 @@ class EndpointNode:
         to the parent nodes. It only includes new variables.
 
         Args:
-            spec_vars [dict]: the new spec_vars.
-            extras [dict]: extra variables used to update the spec_vars.
+            spec_vars (dict): the new spec_vars.
+            extras (dict): extra variables used to update the spec_vars.
         """
         new_spec_vars = {
             key: value
@@ -199,7 +199,7 @@ class EndpointNode:
         """Get all variables in spec_vars from the node and its parents.
 
         Returns:
-            [dict]: dict from the variable's name to its value.
+            dict: dict from the variable's name to its value.
         """
         variables = copy.deepcopy(self.spec_vars.registry)
         if not self.is_root:
@@ -211,7 +211,7 @@ class EndpointNode:
         """Run the requests of the node and all children nodes.
 
         Returns:
-            [iterator]: Iterator that yields the test result of each request.
+            iterator: Iterator that yields the test result of each request.
         """
         for request in self._get_requests():
             try:
@@ -240,10 +240,10 @@ class EndpointNode:
         """Get a specification of the endpoint.
 
         Args:
-            field_name [str]: name of the specification field.
+            field_name (str): name of the specification field.
 
         Returns:
-            [dict]: a dictionary containing the values of the field.
+            dict: a dictionary containing the values of the field.
         """
         values = self.spec.get(field_name, {})
         parent_values = getattr(self.parent, field_name, None)
@@ -257,7 +257,7 @@ class EndpointNode:
         """Get all requests from the node and children nodes as RequestNodes.
 
         Returns:
-            [iterator]: Iterator that yields a RequestNode for
+            iterator: Iterator that yields a RequestNode for
             each request.
         """
         return chain(

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -28,8 +28,8 @@ class RequestNode:
     where each EndpointNode may contain multiple children RequestNode.
 
     Attributes:
-        spec[dict]: dictionary containing the request's specifications
-        endpoint[EndpointNode]: the parent node
+        spec (dict): dictionary containing the request's specifications
+        endpoint (EndpointNode): the parent node
     """
 
     SCOPE = "request"
@@ -145,7 +145,7 @@ class RequestNode:
         """Make HTTP requests and generating test results for the given URLs.
 
         Returns:
-            [dict]: HTTP response and test results with request node name,
+            dict: HTTP response and test results with request node name,
             to be used by the report template.
 
         """
@@ -205,7 +205,7 @@ class RequestNode:
         """Run all tests cases of request node.
 
         Returns:
-            [dict]: Return a dict with test result.
+            dict: Return a dict with test result.
 
         """
         return [test.run() for test in self.tests]
@@ -226,7 +226,7 @@ class RequestNode:
         """Check headers for any content-type different than application/json
 
         Args:
-            headers dict[str, str]: request headers
+            headers (dict[str, str]): request headers
 
         Returns:
             bool: False if convent-type is different then application/json

--- a/scanapi/utils.py
+++ b/scanapi/utils.py
@@ -30,9 +30,9 @@ def _validate_allowed_keys(keys, available_keys, scope):
     """Private function that checks if the spec keys are allowed.
 
     Args:
-        keys [list of strings]: the specification keys
-        available_keys [tuple of string]: the available keys for that scope
-        scope [string]: the scope of the current node: 'root', 'endpoint',
+        keys (list of strings): the specification keys
+        available_keys (tuple of string): the available keys for that scope
+        scope (string): the scope of the current node: 'root', 'endpoint',
         'request' or 'test'
 
     """
@@ -45,9 +45,9 @@ def _validate_required_keys(keys, required_keys, scope):
     """Private function that checks if there is any required key missing.
 
     Args:
-        keys [list of strings]: the specification keys
-        required_keys [tuple of string]: the required keys for that scope
-        scope [string]: the scope of the current node: 'root', 'endpoint',
+        keys (list of strings): the specification keys
+        required_keys (tuple of string): the required keys for that scope
+        scope (string): the scope of the current node: 'root', 'endpoint',
         'request' or 'test'
 
     """
@@ -60,13 +60,13 @@ def session_with_retry(retry_configuration, verify=True):
     """Instantiate a requests session.
 
     Args:
-        retry_configuration [dict]: The retry configuration
+        retry_configuration (dict): The retry configuration
         for a request. (Available for version >= 2.2.0).
-        verify [bool]: SSL certificates used to verify the
+        verify (bool): SSL certificates used to verify the
         identity of requested hosts
 
     Returns:
-        [httpx.Client]: Client
+        httpx.Client: Client
     """
     retry_configuration = retry_configuration or {}
     retries = retry_configuration.get(MAX_RETRIES_KEY, 0)

--- a/wiki/First-Pull-Request.md
+++ b/wiki/First-Pull-Request.md
@@ -48,8 +48,8 @@ class Example:
     """Explain the purpose of the class
 
     Attributes:
-        spec[dict]: Short explanation here
-        parent[type, optional]: Short explanation here
+        spec (dict): Short explanation here
+        parent (type, optional): Short explanation here
     """
 
     def __init__(self, spec, parent=None):
@@ -60,10 +60,10 @@ class Example:
         """Purpose of the function
 
         Args:
-            field_name[str]: Short explanation here
+            field_name (str): Short explanation here
 
         Returns:
-            value[str]: Short explanation here
+            str: Short explanation here
         """
         value = field_name.get('node')
         return value


### PR DESCRIPTION
## Description
Refactors parameter, attribute, and return types inside docstrings
from the old custom format (e.g., `name[type]:` and `[type]:`) to 
the standard Google-style format (e.g., `name (type):` and `type:`).

- Updates parameter brackets to parentheses in Args and Attributes
- Removes external brackets from types in Returns and Raises
- Ensures compatibility with mkdocstrings/griffe parsing

## Motivation behind this PR?
This PR fixes an issue where parameter, attribute, and return types in docstrings were rendered incorrectly by MkDocs/mkdocstrings. The docstrings have been refactored to consistently follow the Google-style formatting guide, ensuring that parameters use parentheses `name (type):` and return types are clean `type:`.

## What type of change is this?
Bug Fix (Documentation / Formatting)

## AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [X] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [X] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [X] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [X] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [X] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [X] This PR does not significantly reduce code or docstring coverage.
- [X] Code follows the project’s style guidelines.
- [X] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue

Closes #932 
