### PR TITLE
fix: Non-reachable APIs (NetworkError, TimeoutException) will not e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Total time delta and response time delta in the HTML report to be more easily human readable
 
 ### Fixed
-- Non-reachable APIs (NetworkError, TimeoutException) will now exit and report the test as errored
+- Non-reachable APIs (NetworkError, TimeoutException) will now exit and report the test as errored [#946](https://github.com/scanapi/scanapi/pull/946).
 
 ## [2.13.2] - 2026-05-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update Total time delta and response time delta in the HTML report to be more easily human readable
 
+### Fixed
+- Non-reachable APIs (NetworkError, TimeoutException) will now exit and report the test as errored
+
 ## [2.13.2] - 2026-05-18
 ### Fixed
 - Include report templates in package distributions to prevent runtime failures during report generation [#920](https://github.com/scanapi/scanapi/pull/920)

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -212,7 +212,7 @@ class EndpointNode:
 
         Returns:
             [iterator]: Iterator that yields the test result of each request.
-        """    
+        """
         for request in self._get_requests():
             try:
                 yield request.run()

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -3,8 +3,8 @@ import logging
 from itertools import chain
 from typing import Any, Dict, Optional
 
-from httpx import CookieConflict, HTTPError, InvalidURL, NetworkError, StreamError, \
-                  TimeoutException
+from httpx import CookieConflict, HTTPError, InvalidURL, NetworkError, \
+                  StreamError, TimeoutException
 
 from scanapi.errors import InvalidKeyError
 from scanapi.evaluators import SpecEvaluator

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -3,7 +3,8 @@ import logging
 from itertools import chain
 from typing import Any, Dict, Optional
 
-from httpx import CookieConflict, HTTPError, InvalidURL, NetworkError, StreamError, TimeoutException
+from httpx import CookieConflict, HTTPError, InvalidURL, NetworkError, StreamError, \
+                  TimeoutException
 
 from scanapi.errors import InvalidKeyError
 from scanapi.evaluators import SpecEvaluator
@@ -217,10 +218,10 @@ class EndpointNode:
             try:
                 yield request.run()
             except (NetworkError, TimeoutException) as e:
-                # NetworkErrors and TimeoutException are hard errors and should exit early
+                # These are hard errors and should exit early with an error
                 error_message = (
-                    f"\nError while connecting for request {request.full_url_path!r}"
-                    f"\n{str(e)}\n"
+                    f"\nError while connecting for request"
+                    f" {request.full_url_path!r}\n{str(e)}\n"
                 )
                 logger.error(error_message)
                 session.exit_code = ExitCode.REQUEST_ERROR
@@ -234,7 +235,6 @@ class EndpointNode:
                 logger.error(error_message)
                 session.exit_code = ExitCode.REQUEST_ERROR
                 continue
-
 
     def _validate(self):
         """Private method that checks if the specification has any invalid key

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -3,7 +3,7 @@ import logging
 from itertools import chain
 from typing import Any, Dict, Optional
 
-from httpx import CookieConflict, HTTPError, InvalidURL, StreamError
+from httpx import CookieConflict, HTTPError, InvalidURL, NetworkError, StreamError, TimeoutException
 
 from scanapi.errors import InvalidKeyError
 from scanapi.evaluators import SpecEvaluator
@@ -212,10 +212,20 @@ class EndpointNode:
 
         Returns:
             [iterator]: Iterator that yields the test result of each request.
-        """
+        """    
         for request in self._get_requests():
             try:
                 yield request.run()
+            except (NetworkError, TimeoutException) as e:
+                # Network
+                error_message = (
+                    f"\nError while connecting for request {request.full_url_path!r}"
+                    f"\n{str(e)}\n"
+                )
+                logger.error(error_message)
+                session.exit_code = ExitCode.REQUEST_ERROR
+                session.increment_errors()
+                return
             except (CookieConflict, HTTPError, InvalidURL, StreamError) as e:
                 error_message = (
                     f"\nError to make request {repr(request.full_url_path)}. "
@@ -224,6 +234,7 @@ class EndpointNode:
                 logger.error(error_message)
                 session.exit_code = ExitCode.REQUEST_ERROR
                 continue
+
 
     def _validate(self):
         """Private method that checks if the specification has any invalid key

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -217,7 +217,7 @@ class EndpointNode:
             try:
                 yield request.run()
             except (NetworkError, TimeoutException) as e:
-                # Network
+                # NetworkErrors and TimeoutException are hard errors and should exit early
                 error_message = (
                     f"\nError while connecting for request {request.full_url_path!r}"
                     f"\n{str(e)}\n"

--- a/tests/unit/tree/endpoint_node/test_run.py
+++ b/tests/unit/tree/endpoint_node/test_run.py
@@ -1,7 +1,7 @@
 import logging
 
 from pytest import fixture, mark
-from httpx import HTTPError
+from httpx import HTTPError, NetworkError, TimeoutException
 
 from scanapi.exit_code import ExitCode
 from scanapi.tree import EndpointNode
@@ -60,7 +60,7 @@ class TestRun:
 
     @mark.context("when there is an error during a request")
     @mark.it("should log the error and change session exit code")
-    def test_when_request_fails(self, mock_run_request, mock_session, caplog):
+    def test_when_request_errors(self, mock_run_request, mock_session, caplog):
         mock_run_request.side_effect = ["foo", HTTPError("error: bar")]
 
         node = EndpointNode(
@@ -96,6 +96,96 @@ class TestRun:
 
         assert (
             "\nError to make request 'http://foo.com/second'. \nerror: bar\n"
+            in caplog.text
+        )
+
+        assert mock_run_request.call_count == 2
+
+        assert mock_session.exit_code == ExitCode.REQUEST_ERROR
+
+    @mark.context("when there is an error reaching the endpoint [NetworkError]")
+    @mark.it("should log the error and change session exit code")
+    def test_when_endpoint_errors_network(self, mock_run_request, mock_session, caplog):
+        mock_run_request.side_effect = ["foo", NetworkError("error: bar")]
+
+        node = EndpointNode(
+            {
+                "endpoints": [
+                    {
+                        "name": "foo",
+                        "requests": [
+                            {
+                                "name": "First",
+                                "path": "http://foo.com/first",
+                            },
+                            {
+                                "name": "Second",
+                                "path": "http://foo.com/second",
+                            },
+                        ],
+                    }
+                ],
+                "name": "node",
+                "requests": [],
+            }
+        )
+
+        requests = []
+        with caplog.at_level(logging.ERROR):
+            requests_gen = node.run()
+
+            for request in requests_gen:
+                requests.append(request)
+
+        assert len(requests) == 1
+
+        assert (
+            "\nError while connecting for request 'http://foo.com/second'\nerror: bar\n"
+            in caplog.text
+        )
+
+        assert mock_run_request.call_count == 2
+
+        assert mock_session.exit_code == ExitCode.REQUEST_ERROR
+
+    @mark.context("when there is an error reaching the endpoint [TimeoutException]")
+    @mark.it("should log the error and change session exit code")
+    def test_when_endpoint_errors_timeout(self, mock_run_request, mock_session, caplog):
+        mock_run_request.side_effect = ["foo", TimeoutException("error: bar")]
+
+        node = EndpointNode(
+            {
+                "endpoints": [
+                    {
+                        "name": "foo",
+                        "requests": [
+                            {
+                                "name": "First",
+                                "path": "http://foo.com/first",
+                            },
+                            {
+                                "name": "Second",
+                                "path": "http://foo.com/second",
+                            },
+                        ],
+                    }
+                ],
+                "name": "node",
+                "requests": [],
+            }
+        )
+
+        requests = []
+        with caplog.at_level(logging.ERROR):
+            requests_gen = node.run()
+
+            for request in requests_gen:
+                requests.append(request)
+
+        assert len(requests) == 1
+
+        assert (
+            "\nError while connecting for request 'http://foo.com/second'\nerror: bar\n"
             in caplog.text
         )
 


### PR DESCRIPTION
…xit and report the test as errored

## Description
Allow ScanAPI to exit early when the API is unreachable because of bad urls, network issues, or timeout issues

## Motivation behind this PR?
Issue #896, previous the tests will run through with soft errors and report that the tests were successful (0 passed, 0 failed) 

## What type of change is this?
Bug fix because network errors shouldn't be reported as a successful test run

## AI Assistance Disclosure (REQUIRED)
- [X] No AI tools were used in preparing this PR.
- [ ] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [X] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [X] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [X] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [X] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [X] This PR does not significantly reduce code or docstring coverage.
- [X] Code follows the project’s style guidelines.
- [X] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #896 
