### PR TITLE
feat: adds collapsible to group requests by top level endpoints/498

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Changed standard report template so it groups requests by top level endpoints in a collapsible [951](github.com/scanapi/scanapi/pull/951)
+- Changed standard report template so it groups requests by top level endpoints in a collapsible [#951](https://github.com/scanapi/scanapi/pull/951).
 
 ### Changed
 - Update Total time delta and response time delta in the HTML report to be more easily human readable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Changed standard report template so it groups requests by top level endpoints in a collapsible
+- Changed standard report template so it groups requests by top level endpoints in a collapsible [951](github.com/scanapi/scanapi/pull/951)
 
 ### Changed
 - Update Total time delta and response time delta in the HTML report to be more easily human readable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Changed standard report template so it groups requests by root child endpoints in a collapsible
+- Changed standard report template so it groups requests by top level endpoints in a collapsible
 
 ### Changed
 - Update Total time delta and response time delta in the HTML report to be more easily human readable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Changed standard report template so it groups requests by root child endpoints in a collapsible
+
+### Changed
 - Update Total time delta and response time delta in the HTML report to be more easily human readable
 
 ### Fixed

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -2,8 +2,7 @@
 import datetime
 import pathlib
 import webbrowser
-
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 from scanapi.console import write_report_path
 from scanapi.session import session

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -2,7 +2,8 @@
 import datetime
 import pathlib
 import webbrowser
-from importlib.metadata import PackageNotFoundError, version
+
+from importlib.metadata import version, PackageNotFoundError
 
 from scanapi.console import write_report_path
 from scanapi.session import session

--- a/scanapi/template_render.py
+++ b/scanapi/template_render.py
@@ -1,3 +1,5 @@
+import itertools
+
 import curlify2
 from jinja2 import Environment, FileSystemLoader, PackageLoader
 
@@ -12,6 +14,7 @@ def render(template_path, context, is_external=False):
     )
     env.filters["curlify"] = curlify2.to_curl
     env.filters["render_body"] = render_body
+    env.filters["group_by_child_endpoint"] = group_by_child_endpoints
     env.globals["is_bytes"] = lambda o: isinstance(o, bytes)
     chosen_template = env.get_template(template_path)
     return chosen_template.render(**context)
@@ -34,3 +37,23 @@ def render_body(request):
     if content_type in ["application/json", "text/plain"]:
         return request.body.decode()
     return f"Can not render. Unsuported content type: {content_type}."
+
+
+def group_by_child_endpoints(results):
+    """
+    Groups results by endpoint name
+
+    Args:
+        [iterator]: iterator of request results
+
+    Returns:
+        [iterator]: an iterator with tuples containing the endpoint name
+        and an iterator for all request results of that endpoint
+    """
+
+    def by_child_endpoint_name(result):
+        endpoint_name = result["endpoint_name"]
+        root, *generations = endpoint_name.split("::")
+        return generations[0] if generations else root or "root"
+
+    return itertools.groupby(results, by_child_endpoint_name)

--- a/scanapi/template_render.py
+++ b/scanapi/template_render.py
@@ -14,7 +14,7 @@ def render(template_path, context, is_external=False):
     )
     env.filters["curlify"] = curlify2.to_curl
     env.filters["render_body"] = render_body
-    env.filters["group_by_child_endpoint"] = group_by_child_endpoints
+    env.filters["group_by_top_level_endpoint"] = group_by_top_level_endpoint
     env.globals["is_bytes"] = lambda o: isinstance(o, bytes)
     chosen_template = env.get_template(template_path)
     return chosen_template.render(**context)
@@ -39,7 +39,7 @@ def render_body(request):
     return f"Can not render. Unsuported content type: {content_type}."
 
 
-def group_by_child_endpoints(results):
+def group_by_top_level_endpoint(results):
     """
     Groups results by endpoint name
 
@@ -51,9 +51,9 @@ def group_by_child_endpoints(results):
         and an iterator for all request results of that endpoint
     """
 
-    def by_child_endpoint_name(result):
+    def by_top_level_endpoint_name(result):
         endpoint_name = result["endpoint_name"]
         root, *generations = endpoint_name.split("::")
         return generations[0] if generations else root or "root"
 
-    return itertools.groupby(results, by_child_endpoint_name)
+    return itertools.groupby(results, by_top_level_endpoint_name)

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -508,7 +508,7 @@
 
         <!-- summary_box -->
         <div class="summary__endpoint">
-            {% for child_endpoint_name, result_group in results | group_by_child_endpoint -%}
+            {% for top_level_endpoint_name, result_group in results | group_by_top_level_endpoint -%}
             {% set outer_loop = loop %}
 
             <div class="endpoint endpoint--group" id="endpoint_group_{{ outer_loop.index }}">
@@ -525,7 +525,7 @@
                 >
                     <span class="endpoint__titleInfo">
                         <span class="http_method">
-                            {{ child_endpoint_name }}
+                            {{ top_level_endpoint_name }}
                         </span>
                     </span>
                 </label>

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -479,7 +479,14 @@
 
         <!-- summary_box -->
         <div class="summary__endpoint">
-            {% for result in results -%}
+            {% for child_endpoint_name, result_group in results | group_by_child_endpoint -%}
+            {% set outer_loop = loop %}
+            <div class="endpoint" id="endpoint_{{ outer_loop.index | string }}">
+            <input type="checkbox" class="endpoint__checkbox" id="chck_{{ outer_loop.index | string }}" />
+            <label class="endpoint__title" for="chck_{{ outer_loop.index | string }}">
+                <span class=http_method>{{ child_endpoint_name }} </span>
+            </label>
+            {% for result in result_group %}
             {% set response = result["response"] %}
             {% set tests = result["tests_results"] %}
             {% set endpoint_status_label = "P" if result["no_failure"] else "F" %}
@@ -487,11 +494,11 @@
             {% set options = result["options"] %}
             {% set verify = options.get("verify", True) %}
 
-            <div class="endpoint" id="endpoint_{{ loop.index | string }}">
-                <input type="checkbox" class="endpoint__checkbox" id="chck_{{ loop.index | string }}" />
-                <label class="endpoint__title" for="chck_{{ loop.index | string }}">
+                <div class="endpoint" id="endpoint_{{ outer_loop.index | string }}_{{ loop.index | string }}">
+                <input type="checkbox" class="endpoint__checkbox" id="chck_{{ outer_loop.index | string }}_{{ loop.index | string }}" />
+                <label class="endpoint__title" for="chck_{{ outer_loop.index | string }}_{{ loop.index | string }}">
                     <span class="endpoint__url">
-                        <img data-anchor="endpoint_{{ loop.index | string }}" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
+                        <img data-anchor="endpoint_{{ outer_loop.index | string }}_{{ loop.index | string }}" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
                         <span class="http_method">{{request.method}}</span> {{ request.path_url }}
                         <span class="endpoint__request_node_name">{{ result.request_node_name }}</span>
                     </span>
@@ -647,7 +654,9 @@
                 </div>
             </div>
             {% endfor %}
+        {% endfor %}
         </div>
+            </div>
 
         {% set final_status = "passed" if session.succeed else "failed" %}
         <div class="summary__tests summary__tests--{{final_status}}">

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -481,11 +481,25 @@
         <div class="summary__endpoint">
             {% for child_endpoint_name, result_group in results | group_by_child_endpoint -%}
             {% set outer_loop = loop %}
-            <div class="endpoint" id="endpoint_{{ outer_loop.index | string }}">
-            <input type="checkbox" class="endpoint__checkbox" id="chck_{{ outer_loop.index | string }}" />
-            <label class="endpoint__title" for="chck_{{ outer_loop.index | string }}">
-                <span class=http_method>{{ child_endpoint_name }} </span>
-            </label>
+
+            <div class="endpoint endpoint--group" id="endpoint_group_{{ outer_loop.index }}">
+
+                <input
+                    type="checkbox"
+                    class="endpoint__checkbox"
+                    id="group_chck_{{ outer_loop.index }}"
+                />
+
+                <label
+                    class="endpoint__title endpoint__title--group"
+                    for="group_chck_{{ outer_loop.index }}"
+                >
+                    <span class="http_method">
+                        {{ child_endpoint_name }}
+                    </span>
+                </label>
+
+                <div class="endpoint__content endpoint__content--group">
             {% for result in result_group %}
             {% set response = result["response"] %}
             {% set tests = result["tests_results"] %}
@@ -654,6 +668,8 @@
                 </div>
             </div>
             {% endfor %}
+            </div>
+        </div>
         {% endfor %}
         </div>
             </div>

--- a/scanapi/templates/report.html
+++ b/scanapi/templates/report.html
@@ -254,6 +254,35 @@
             line-break: anywhere;
         }
 
+        .endpoint--group {
+            margin-bottom: 20px;
+        }
+
+        .endpoint__content--group {
+            padding-top: 16px;
+        }
+
+        .endpoint__title--group {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 18px 20px;
+            background-color: #e9ecef;
+            font-size: 22px;
+            font-weight: bold;
+        }
+
+        .endpoint__title--group .endpoint__titleInfo {
+            width: 100%;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .endpoint--group > .endpoint__checkbox:checked + .endpoint__title {
+            border-radius: 10px;
+        }
+
         .http_method {
             font-weight: bold;
         }
@@ -494,8 +523,10 @@
                     class="endpoint__title endpoint__title--group"
                     for="group_chck_{{ outer_loop.index }}"
                 >
-                    <span class="http_method">
-                        {{ child_endpoint_name }}
+                    <span class="endpoint__titleInfo">
+                        <span class="http_method">
+                            {{ child_endpoint_name }}
+                        </span>
                     </span>
                 </label>
 
@@ -508,7 +539,7 @@
             {% set options = result["options"] %}
             {% set verify = options.get("verify", True) %}
 
-                <div class="endpoint" id="endpoint_{{ outer_loop.index | string }}_{{ loop.index | string }}">
+            <div class="endpoint" id="endpoint_{{ outer_loop.index | string }}_{{ loop.index | string }}">
                 <input type="checkbox" class="endpoint__checkbox" id="chck_{{ outer_loop.index | string }}_{{ loop.index | string }}" />
                 <label class="endpoint__title" for="chck_{{ outer_loop.index | string }}_{{ loop.index | string }}">
                     <span class="endpoint__url">
@@ -672,7 +703,6 @@
         </div>
         {% endfor %}
         </div>
-            </div>
 
         {% set final_status = "passed" if session.succeed else "failed" %}
         <div class="summary__tests summary__tests--{{final_status}}">

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -194,6 +194,7 @@ class RequestNode:
             ),
             "request_node_name": self.name,
             "options": self.options,
+            "endpoint_name": self.endpoint.name,
         }
 
         if not settings["no_report"]:

--- a/tests/unit/test_group_by_child_endpoints.py
+++ b/tests/unit/test_group_by_child_endpoints.py
@@ -1,11 +1,11 @@
 from pytest import mark
 
-from scanapi.template_render import group_by_child_endpoints
+from scanapi.template_render import group_by_top_level_endpoint
 
 
 @mark.describe("template_render")
-@mark.describe("group_by_child_endpoints")
-class TestGroupByChildEndpoints:
+@mark.describe("group_by_top_level_endpoint")
+class TestGroupByTopLevelEndpoint:
     @mark.context("given nested requests results")
     @mark.it("should group them by the endpoint closest to root")
     def test_group_nested_endpoints(self):
@@ -19,7 +19,7 @@ class TestGroupByChildEndpoints:
 
         grouped_results = [
             (endpoint_name, list(results))
-            for endpoint_name, results in group_by_child_endpoints(results)
+            for endpoint_name, results in group_by_top_level_endpoint(results)
         ]
 
         assert len(grouped_results) == 2
@@ -43,7 +43,7 @@ class TestGroupByChildEndpoints:
 
         grouped_results = [
             (endpoint_name, list(results))
-            for endpoint_name, results in group_by_child_endpoints(results)
+            for endpoint_name, results in group_by_top_level_endpoint(results)
         ]
 
         assert len(grouped_results) == 1
@@ -64,7 +64,7 @@ class TestGroupByChildEndpoints:
 
         grouped_results = [
             (endpoint_name, list(results))
-            for endpoint_name, results in group_by_child_endpoints(results)
+            for endpoint_name, results in group_by_top_level_endpoint(results)
         ]
 
         assert len(grouped_results) == 2

--- a/tests/unit/test_group_by_child_endpoints.py
+++ b/tests/unit/test_group_by_child_endpoints.py
@@ -1,0 +1,78 @@
+from pytest import mark
+
+from scanapi.template_render import group_by_child_endpoints
+
+
+@mark.describe("template_render")
+@mark.describe("group_by_child_endpoints")
+class TestGroupByChildEndpoints:
+    @mark.context("given nested requests results")
+    @mark.it("should group them by the endpoint closest to root")
+    def test_group_nested_endpoints(self):
+        results = [
+            {"endpoint_name": "root"},
+            {"endpoint_name": "root"},
+            {"endpoint_name": "root::branch"},
+            {"endpoint_name": "root::branch::leaf"},
+            {"endpoint_name": "root::branch::leaf"},
+        ]
+
+        grouped_results = [
+            (endpoint_name, list(results))
+            for endpoint_name, results in group_by_child_endpoints(results)
+        ]
+
+        assert len(grouped_results) == 2
+
+        endpoint_name, endpoint_results = grouped_results[0]
+        assert endpoint_name == "root"
+        assert len(list(endpoint_results)) == 2
+
+        endpoint_name, endpoint_results = grouped_results[1]
+        assert endpoint_name == "branch"
+        assert len(list(endpoint_results)) == 3
+
+    @mark.context("given flat requests results")
+    @mark.it("should group them all as root")
+    def test_group_flat_endpoints(self):
+        results = [
+            {"endpoint_name": "root"},
+            {"endpoint_name": "root"},
+            {"endpoint_name": "root"},
+        ]
+
+        grouped_results = [
+            (endpoint_name, list(results))
+            for endpoint_name, results in group_by_child_endpoints(results)
+        ]
+
+        assert len(grouped_results) == 1
+
+        endpoint_name, endpoint_results = grouped_results[0]
+        assert endpoint_name == "root"
+        assert len(list(endpoint_results)) == 3
+
+    @mark.context("given an empty root endpoint name")
+    @mark.it("should call it root")
+    def test_group_empty_root_name(self):
+        results = [
+            {"endpoint_name": ""},
+            {"endpoint_name": ""},
+            {"endpoint_name": ""},
+            {"endpoint_name": "::leaf"},
+        ]
+
+        grouped_results = [
+            (endpoint_name, list(results))
+            for endpoint_name, results in group_by_child_endpoints(results)
+        ]
+
+        assert len(grouped_results) == 2
+
+        endpoint_name, endpoint_results = grouped_results[0]
+        assert endpoint_name == "root"
+        assert len(list(endpoint_results)) == 3
+
+        endpoint_name, endpoint_results = grouped_results[1]
+        assert endpoint_name == "leaf"
+        assert len(list(endpoint_results)) == 1

--- a/tests/unit/tree/request_node/test_run.py
+++ b/tests/unit/tree/request_node/test_run.py
@@ -64,6 +64,7 @@ class TestRun:
             "no_failure": True,
             "request_node_name": "request_name",
             "options": {"timeout": 2.3, "verify": False},
+            "endpoint_name": "endpoint_name",
         }
 
     @mark.context("when has no `Content-Type` header")
@@ -254,4 +255,5 @@ class TestRun:
             "no_failure": expected_no_failure,
             "request_node_name": "request_name",
             "options": {},
+            "endpoint_name": "endpoint_name",
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
In the report generation, I added a simple collapsible so, using regular report, requests are groped by top level endpoints (endpoints that are direct children of the root node).

This is what it looks like:
<figure>
<img width="1197" height="1570" alt="image" src="https://github.com/user-attachments/assets/dc4c4067-50aa-4588-b9f2-05fe20ede956" />
<figcaption>scanapi example test from examples/demo-api</figcaption>
<figure>

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
It was a feature request to improve usability, so requests can be grouped by top level endpoints.\
It was requested in #498

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Feature

## AI Assistance Disclosure (REQUIRED)
I used OpenAI's GPT-5.5, on chatgpt.com, to guide me through CSS classes so I could style the collapsible accordingly.\
I'm not known for my styling skills :sweat_smile:
- [ ] No AI tools were used in preparing this PR.
- [X] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.


## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [X] A changelog entry was added, or this PR does not require one. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Changelog-Guide.md)
- [X] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Writing-Tests.md)
- [X] All unit tests pass locally. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md#tests)
- [X] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/First-Pull-Request.md#7-make-your-changes)
- [X] This PR does not significantly reduce code or docstring coverage.
- [X] Code follows the project’s style guidelines.
- [X] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://github.com/scanapi/scanapi/blob/main/wiki/Run-ScanAPI-in-Dev-Env.md)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #498 
