### PR TITLE
ci: add reusable docs-only change check

### DIFF
--- a/.github/actions/changed-files-check/action.yml
+++ b/.github/actions/changed-files-check/action.yml
@@ -1,0 +1,22 @@
+name: Changed Files Check
+description: Detect documentation-only pull request changes for workflow job gating.
+
+outputs:
+  docs_only:
+    description: Whether every changed file is documentation-related.
+    value: ${{ steps.docs-filter.outputs.docs_only }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect documentation-only changes
+      id: docs-filter
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+      with:
+        predicate-quantifier: every
+        filters: |
+          docs_only:
+            - 'docs/**'
+            - 'mkdocs.yml'
+            - '.readthedocs.yaml'
+            - '*.md'

--- a/.github/actions/changed-files-check/action.yml
+++ b/.github/actions/changed-files-check/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Detect documentation-only changes
       id: docs-filter
-      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         predicate-quantifier: every
         filters: |

--- a/.github/workflows/pytest-and-codecov.yml
+++ b/.github/workflows/pytest-and-codecov.yml
@@ -10,8 +10,22 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.changed-files.outputs.docs_only }}
+    steps:
+      - name: Checkout ScanAPI repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check changed files
+        id: changed-files
+        uses: ./.github/actions/changed-files-check
+
   run:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -11,8 +11,22 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.changed-files.outputs.docs_only }}
+    steps:
+      - name: Checkout ScanAPI repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check changed files
+        id: changed-files
+        uses: ./.github/actions/changed-files-check
+
   poke-api:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -25,6 +39,8 @@ jobs:
 
   httpbingo-api:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,6 +53,8 @@ jobs:
 
   demo-api:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
﻿Closes #964

## Summary
- add a reusable local `changed-files-check` composite action for documentation-only change detection
- use `dorny/paths-filter` inside the local action instead of maintaining custom shell/API detection logic
- wire the reusable `docs_only` output into the examples and pytest/codecov workflows

## Impact
Documentation-only pull requests can skip the external examples jobs and pytest matrix, while code changes and pushes to `main` continue to run the full workflows.

## Validation
- `uv run python -c "import yaml, pathlib; [yaml.safe_load(path.open(encoding='utf-8')) for path in [pathlib.Path('.github/actions/changed-files-check/action.yml'), pathlib.Path('.github/workflows/run-examples.yml'), pathlib.Path('.github/workflows/pytest-and-codecov.yml')]]; print('yaml valid')"` - passed
- `git diff --check` - passed
