### PR TITLE
chore: fix contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thanks for taking the time to contribute! 🙇‍♀️🙇‍♂️ Every little bit of help counts!
 
-The Contributing documentation is available at our [Contributor Guide](https://scanapi.readthedocs.io/en/latest/contributor-guide/contributing/).
+The Contributing documentation is available at our [Contributor Guide](https://scanapi.readthedocs.io/en/latest/contributor-guide/).


### PR DESCRIPTION
## Description
Fix link to read the docs contributing guide

## Motivation behind this PR?
The contributing guide link is broken which made it hard to follow the instructions for contributing.

## What type of change is this?
Chore

## AI Assistance Disclosure (REQUIRED)
- [x] No AI tools were used in preparing this PR.
- [ ] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

I had to ask a human for help understanding why https://scanapi.readthedocs.io/en/latest/contributor-guide/contributing/ rendered wrong.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/changelog-guide/)
- [ ] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide/)
- [ ] All unit tests pass locally. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide#run)
- [ ] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/first-pull-request/)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [ ] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/run-scanapi-dev/)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
- Closes #969
