### PR TITLE
ci: fix docs-only CI skip detection

### DIFF
--- a/.github/actions/changed-files-check/action.yml
+++ b/.github/actions/changed-files-check/action.yml
@@ -4,19 +4,20 @@ description: Detect documentation-only pull request changes for workflow job gat
 outputs:
   docs_only:
     description: Whether every changed file is documentation-related.
-    value: ${{ steps.docs-filter.outputs.docs_only }}
+    value: ${{ steps.non-docs-filter.outputs.non_docs_changed != 'true' }}
 
 runs:
   using: composite
   steps:
-    - name: Detect documentation-only changes
-      id: docs-filter
+    - name: Detect non-documentation changes
+      id: non-docs-filter
       uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         predicate-quantifier: every
         filters: |
-          docs_only:
-            - 'docs/**'
-            - 'mkdocs.yml'
-            - '.readthedocs.yaml'
-            - '*.md'
+          non_docs_changed:
+            - '**'
+            - '!docs/**'
+            - '!mkdocs.yml'
+            - '!.readthedocs.yaml'
+            - '!**/*.md'

--- a/.github/workflows/pytest-and-codecov.yml
+++ b/.github/workflows/pytest-and-codecov.yml
@@ -25,7 +25,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -26,7 +26,7 @@ jobs:
   poke-api:
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,7 +40,7 @@ jobs:
   httpbingo-api:
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,7 +54,7 @@ jobs:
   demo-api:
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- fix the reusable changed-files action so docs-only PRs are detected by checking for non-documentation changes
- gate pytest/codecov and examples jobs on `docs_only` for both pull requests and pushes to `main`

## Root cause
The previous `docs_only` filter used `predicate-quantifier: every` with multiple documentation patterns. That makes a changed file need to satisfy every listed pattern at once, so a docs file such as `docs/assets/images/scanapi-icon-dark.svg` did not match and `docs_only` stayed `false`.

## Validation
- Parsed the updated action/workflow YAML files with `yaml.safe_load`
- Ran `git diff --check`

Fixes #964