### PR TITLE
ci: move actions write permission on close-stale-issues-v1.yml

### DIFF
--- a/.github/workflows/close-stale-issues-v1.yml
+++ b/.github/workflows/close-stale-issues-v1.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  actions: write
 
 env:
   ISSUE_STALE_DAYS: '45'
@@ -19,4 +18,6 @@ env:
 jobs:
   close_stale_issues:
     name: Close stale issues and PRs
+    permissions:
+      actions: write
     uses: cumbucadev/shared-workflows/.github/workflows/close-stale-issues-v1.yml@2535d1542434bda3afa064424a687f0c368db494


### PR DESCRIPTION
to avoid this warning:

<img width="937" height="417" alt="image" src="https://github.com/user-attachments/assets/125b315f-c8ac-4cf5-826b-c0157694376e" />
