### PR TITLE
fix: replace deprecated pytest-freezegun with time-machine

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -83,7 +83,7 @@ Python 3.12
 │   ├── httpx, packaging, restrictedpython
 │   └── MarkupSafe (pinned: 3.0.3)
 └── Development
-    ├── Testing: pytest, pytest-cov, pytest-freezegun, pytest-mock
+    ├── Testing: pytest, pytest-cov, time-machine, pytest-mock
     ├── Linting: ruff, pre-commit
     ├── Type checking: mypy, types-*
     ├── Documentation: sphinx, sphinx_rtd_theme

--- a/.devcontainer/VISUAL_MAP.md
+++ b/.devcontainer/VISUAL_MAP.md
@@ -81,7 +81,7 @@ Python 3.12
 └── Development (optional)
     ├── Testing
     │   ├── pytest, pytest-cov
-    │   ├── pytest-freezegun
+    │   ├── time-machine
     │   └── pytest-mock
     ├── Linting
     │   ├── ruff, pre-commit

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ This tutorial helps you to create integration tests for your REST API using Scan
 ScanAPI aims to minimize dependency conflicts and ensure a smooth developer experience. Most dependencies are specified as compatible version ranges to allow flexibility and avoid unnecessary conflicts. However, a few dependencies are strictly pinned for stability:
 
 - **MarkupSafe==3.0.3**: Pinned to the latest version for security and compatibility. Relax if future versions are verified safe.
-- **pytest-freezegun==0.4.2**: This package is unmaintained and only 0.4.2 is available. Strict pin is required for test stability.
 - **requests-mock==1.12.1**: Pinned to the latest version for compatibility. Relax if future versions are verified safe.
 
 All other dependencies use safe version ranges (e.g., `>=X.Y,<X+1.0`) to reduce the likelihood of dependency conflicts. If you encounter issues with dependency installation, please open an issue or PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pymdown-extensions>=10.21.3,<11.0.0",
     "pytest>=9.0.3,<10.0.0",
     "pytest-cov>=7.0.0,<8.0.0",
-    "pytest-freezegun==0.4.2",  # Unmaintained; strict pin required for stability
+    "time-machine>=3.0,<4.0",
     "pytest-it>=0.1.5,<0.2.0",
     "pytest-mock>=3.14.0,<4.0.0",
     "requests-mock>=1.12,<2.0.0",

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -1,6 +1,7 @@
 import pathlib
+from datetime import datetime
 
-from freezegun.api import FakeDatetime
+import time_machine
 from pytest import fixture, mark
 
 from scanapi.reporter import Reporter
@@ -57,8 +58,12 @@ class TestInit:
 
 @mark.describe("reporter")
 @mark.describe("write")
-@mark.freeze_time("2020-05-12 11:32:34")
 class TestWrite:
+    @fixture(autouse=True)
+    def freeze_time(self):
+        with time_machine.travel("2020-05-12 11:32:34", tick=False):
+            yield
+
     @fixture
     def mocked__render(self, mocker):
         return mocker.patch("scanapi.reporter.render")
@@ -78,7 +83,7 @@ class TestWrite:
     @fixture
     def context(self, mocked__session):
         return {
-            "now": FakeDatetime(2020, 5, 12, 11, 32, 34),
+            "now": datetime(2020, 5, 12, 11, 32, 34),
             "project_name": "",
             "results": fake_results,
             "session": mocked__session,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,5 +1,6 @@
 from random import randrange
 
+import time_machine
 from pytest import mark, raises
 
 from scanapi.session import Session
@@ -36,7 +37,7 @@ class TestSucceed:
 @mark.describe("start")
 class TestStart:
     @mark.it("should initialize started_at with current time")
-    @mark.freeze_time("2020-06-15 18:54:57")
+    @time_machine.travel("2020-06-15 18:54:57", tick=False)
     def test_init_started_at(self):
         session = Session()
 
@@ -108,10 +109,9 @@ class TestIncrementErrors:
 @mark.describe("elapsed_time")
 class TestElapsedTime:
     @mark.it("should return time")
-    @mark.freeze_time("2020-06-15 18:54:57")
-    def test_return_time(self, freezer):
+    @time_machine.travel("2020-06-15 18:54:57", tick=False)
+    def test_return_time(self):
         session = Session()
 
-        freezer.move_to("2020-06-15 18:56:38")
-
-        assert str(session.elapsed_time()) == "0:01:41"
+        with time_machine.travel("2020-06-15 18:56:38", tick=False):
+            assert str(session.elapsed_time()) == "0:01:41"


### PR DESCRIPTION
## Description
Replaces unmaintained `pytest-freezegun` (last release 2020) with `time-machine`, the actively maintained successor. All `@mark.freeze_time` decorators and `freezer.move_to()` calls are replaced with `time_machine.travel()` using the same timedate strings. The fixture pattern is preserved, no test logic changes.

## Motivation behind this PR?
`pytest-freezegun==0.4.2` generates various deprecation warnings and has no maintenance path forward. `time-machine` is the drop in replacement with a near identical API and ongoing support. Replacing it cleans up test output and removes a pinned unmaintained dependency.

## What type of change is this?
Bug Fix

## AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.
AI tools used: GitHub Copilot in VSCode for inline suggestions during migration. All changes reviewed and verified manually.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/changelog-guide/)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide/)
- [x] All unit tests pass locally. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide#run)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/first-pull-request/)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/run-scanapi-dev/)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #957
