### PR TITLE
fix: restore hashed dependencies in Dockerfile and add Docker CI/CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,17 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"        # 09:00 on the 1st and 15th
+      timezone: "America/Sao_Paulo"
+    cooldown:
+      default-days: 10
+    open-pull-requests-limit: 1
+    labels: ["dependencies", "docker"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,38 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: Build and push Docker image to DockerHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract version from release tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          push: true
+          tags: |
+            scanapi/scanapi:${{ steps.version.outputs.tag }}
+            scanapi/scanapi:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM python:3.10.4-bullseye
+FROM python:3.10.4-bullseye@sha256:86862fd2ad17902cc3a95b7effd257dfd043151f05d280170bdd6ff34f7bc78b
 
 LABEL maintainer="github.com/camilamaia"
 
 ENV PATH="~/.local/bin:${PATH}"
 
-RUN pip install pip setuptools --upgrade
+RUN python -m pip install --no-cache-dir \
+    pip==26.1.2 --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
+    setuptools==82.0.1 --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
 
-RUN python -m pip install --no-cache-dir scanapi==2.13.2
+RUN python -m pip install --no-cache-dir \
+    scanapi==2.13.2 --hash=sha256:6d31091d43521f4fc3ead545bdf72af6e18ce19e682bab57733212213bd74a8b
 
 COPY . /app
 


### PR DESCRIPTION
## Summary

Fixes #916 — Restores hash-verified dependency installations in the Dockerfile and adds automated DockerHub publishing.

## Changes

### Dockerfile
- Pinned base image `python:3.10.4-bullseye` with its digest (`sha256:86862fd...`)
- Restored `pip==26.1.2` and `setuptools==82.0.1` with correct sha256 hashes
- Pinned `scanapi==2.13.2` with its hash

### New: `.github/workflows/publish-docker.yml`
- Automated Docker image build and push to DockerHub on every release
- Tags images with the release version and `latest`
- Uses pinned action versions with commit hashes (for supply chain security)

### Updated: `.github/dependabot.yml`
- Added `docker` package ecosystem so Dependabot automatically opens PRs when base image or pip/setuptools release new versions — preventing future hash mismatches

## How to test
```bash
docker build --no-cache -t scanapi:test .
docker run --rm scanapi:test scanapi --version
```

## Notes
- The workflow requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to be configured in the repository settings
- Future dependency hash updates will be handled automatically by Dependabot