### PR TITLE
build: Replace pytest-freezegun with freezegun

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pymdown-extensions>=10.21.3,<11.0.0",
     "pytest>=9.0.3,<10.0.0",
     "pytest-cov>=7.0.0,<8.0.0",
-    "pytest-freezegun==0.4.2",  # Unmaintained; strict pin required for stability
+    "freezegun>=1.5.0,<2.0.0",  # Maintained alternative to pytest-freezegun
     "pytest-it>=0.1.5,<0.2.0",
     "pytest-mock>=3.14.0,<4.0.0",
     "requests-mock>=1.12,<2.0.0",

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -1,5 +1,6 @@
 import pathlib
 
+from freezegun import freeze_time
 from freezegun.api import FakeDatetime
 from pytest import fixture, mark
 
@@ -57,7 +58,7 @@ class TestInit:
 
 @mark.describe("reporter")
 @mark.describe("write")
-@mark.freeze_time("2020-05-12 11:32:34")
+@freeze_time("2020-05-12 11:32:34")
 class TestWrite:
     @fixture
     def mocked__render(self, mocker):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,5 +1,6 @@
 from random import randrange
 
+from freezegun import freeze_time
 from pytest import mark, raises
 
 from scanapi.session import Session
@@ -36,7 +37,7 @@ class TestSucceed:
 @mark.describe("start")
 class TestStart:
     @mark.it("should initialize started_at with current time")
-    @mark.freeze_time("2020-06-15 18:54:57")
+    @freeze_time("2020-06-15 18:54:57")
     def test_init_started_at(self):
         session = Session()
 
@@ -108,10 +109,9 @@ class TestIncrementErrors:
 @mark.describe("elapsed_time")
 class TestElapsedTime:
     @mark.it("should return time")
-    @mark.freeze_time("2020-06-15 18:54:57")
-    def test_return_time(self, freezer):
-        session = Session()
+    def test_return_time(self):
+        with freeze_time("2020-06-15 18:54:57") as frozen_time:
+            session = Session()
+            frozen_time.move_to("2020-06-15 18:56:38")
 
-        freezer.move_to("2020-06-15 18:56:38")
-
-        assert str(session.elapsed_time()) == "0:01:41"
+            assert str(session.elapsed_time()) == "0:01:41"


### PR DESCRIPTION
## Description
This PR updates the test suite to replace the deprecated pytest-freezegun dependency with the maintained freezegun package.

## Motivation behind this PR?
This change is needed to keep the test environment using a maintained dependency and avoid relying on an unmaintained plugin.

## What type of change is this?
Bug Fix 

## AI Assistance Disclosure (REQUIRED)
- [X] No AI tools were used in preparing this PR.
- [ ] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
-  Unit tests were updated as needed.
-  All unit tests pass locally.

## Issue
Closes #<issue_number>
No issue linked
