### PR TITLE
ci: upgrade Codecov GitHub Action to v7

### DIFF
--- a/.github/workflows/pytest-and-codecov.yml
+++ b/.github/workflows/pytest-and-codecov.yml
@@ -57,7 +57,7 @@ jobs:
       # Upload coverage report only if running on the main repository (not a fork)
       - name: Upload coverage report to codecov.io
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Upgrade Codecov GitHub Action to v7 to fix GPG verification

## Description
<!--- Describe your changes -->
Upgrade the Codecov GitHub Action from v6 to v7.

This update includes the fix for Codecov's recent Keybase migration, where the GPG public key moved from `codecovsecurity` to `codecovsecops`. Without this update, the workflow may fail during CLI signature verification with errors such as `No public key` or `Could not verify signature`.

## References

- https://github.com/codecov/codecov-action/releases/tag/v7.0.0
- https://github.com/codecov/codecov-action

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
Pipeline broken: https://github.com/scanapi/scanapi/actions/runs/30018972006/job/89291469244#step:7:363

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
fix

## AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/changelog-guide/)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide/)
- [x] All unit tests pass locally. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide#run)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/first-pull-request/)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/run-scanapi-dev/)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #1024
