### PR TITLE
docs: add tutorial and docs index files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ ScanAPI helps you automate API testing and documentation from YAML-based API spe
 
 ## Quick Start
 
-- [User Guide](user-guide/docs/index.md) — Learn how to install, configure, and run ScanAPI.
+- [User Guide](user-guide/index.md) — Learn how to install, configure, and run ScanAPI.
 - [API Reference](api.md) — Browse the generated Python API docs from `scanapi` docstrings.
 - [Contributor Guide](contributor-guide/index.md) — Get started contributing to the project.
 - [Changelog](changelog.md) — See what changed in recent releases.

--- a/docs/user-guide/docs/index.md
+++ b/docs/user-guide/docs/index.md
@@ -1,52 +1,20 @@
-# Quick Start
+# Docs
 
-## Requirements
+- [Quick Start](quick_start.md)
 
-- [pip][pip-installation]
+## Specification
 
-## How to install
+- [Basic Structure](specification/basic_structure.md)
+- [API Specification Keys](specification/api_specification_keys.md)
+- [API Spec in Multiple Files](specification/api_spec_in_multiple_files.md)
+- [Chaining Requests](specification/chaining_requests.md)
+- [Custom Variables](specification/chaining_requests.md)
+- [Environment Variables](specification/environment_variables.md)
+- [Python Code](specification/python_code.md)
+- [Retry](specification/retry.md)
 
-```bash
-$ pip install scanapi
-```
-
-## Basic Usage
-
-You will need to write the API's specification and save it as a **YAML** or **JSON** file.
-For example:
-
-```yaml
-endpoints:
-  - name: scanapi-demo # The API's name of your API
-    path: http://demo.scanapi.dev/api/v1 # The API's base url
-    requests:
-      - name: list_all_users # The name of the first request
-        path: users/ # The path of the first request
-        method: get # The HTTP method of the first request
-        tests:
-          - name: status_code_is_200 # The name of the first test for this request
-            assert: ${{ response.status_code == 200 }} # The assertion
-```
-
-And run the scanapi command
-
-```bash
-$ scanapi run <file_path>
-```
-
-Then, the lib will hit the specified endpoints and generate a `scanapi-report.html` file with the report results.
-
-<p align="center">
-  <img
-    src="https://raw.githubusercontent.com/scanapi/scanapi/main/images/report-print-closed.png"
-    width="700"
-    alt="An overview screenshot of the report."
-  >
-  <img
-    src="https://raw.githubusercontent.com/scanapi/scanapi/main/images/report-print-opened.png"
-    width="700"
-    alt="A screenshot of the report showing the request details."
-  >
-</p>
-
-[pip-installation]: https://pip.pypa.io/en/stable/installing/
+## Configuration
+- [Config File](configuration/config_file.md)
+- [Custom Report](configuration/custom_report.md)
+- [Hiding Sensitive Information](configuration/hiding_sensitive_information.md)
+- [ScanAPI CLI](configuration/scanapi_cli.md)

--- a/docs/user-guide/docs/quick_start.md
+++ b/docs/user-guide/docs/quick_start.md
@@ -1,0 +1,52 @@
+# Quick Start
+
+## Requirements
+
+- [pip][pip-installation]
+
+## How to install
+
+```bash
+$ pip install scanapi
+```
+
+## Basic Usage
+
+You will need to write the API's specification and save it as a **YAML** or **JSON** file.
+For example:
+
+```yaml
+endpoints:
+  - name: scanapi-demo # The API's name of your API
+    path: http://demo.scanapi.dev/api/v1 # The API's base url
+    requests:
+      - name: list_all_users # The name of the first request
+        path: users/ # The path of the first request
+        method: get # The HTTP method of the first request
+        tests:
+          - name: status_code_is_200 # The name of the first test for this request
+            assert: ${{ response.status_code == 200 }} # The assertion
+```
+
+And run the scanapi command
+
+```bash
+$ scanapi run <file_path>
+```
+
+Then, the lib will hit the specified endpoints and generate a `scanapi-report.html` file with the report results.
+
+<p align="center">
+  <img
+    src="https://raw.githubusercontent.com/scanapi/scanapi/main/images/report-print-closed.png"
+    width="700"
+    alt="An overview screenshot of the report."
+  >
+  <img
+    src="https://raw.githubusercontent.com/scanapi/scanapi/main/images/report-print-opened.png"
+    width="700"
+    alt="A screenshot of the report showing the request details."
+  >
+</p>
+
+[pip-installation]: https://pip.pypa.io/en/stable/installing/

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,4 +1,4 @@
 # User Guide
 
 - [Docs](docs/index.md)
-- [Tutorial](tutorial/step01.md)
+- [Tutorial](tutorial/index.md)

--- a/docs/user-guide/tutorial/index.md
+++ b/docs/user-guide/tutorial/index.md
@@ -1,0 +1,15 @@
+# Tutorial
+
+1. [Setup](step01.md)
+1. [API Sign Up](step02.md)
+1. [Run](step03.md)
+1. [Tests](step04.md)
+1. [Env Vars](step05.md)
+1. [Hide Info](step06.md)
+1. [Chaining Requests](step07.md)
+1. [Nested Endpoints](step08.md)
+1. [Default Values](step09.md)
+1. [Include](step10.md)
+1. [Project Name](step11.md)
+1. [Custom Report](step12.md)
+1. [Add to Project](step13.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,9 @@ nav:
   - User Guide:
     - user-guide/index.md
     - Docs:
+      - user-guide/docs/index.md
       - Quick Start:
-        - user-guide/docs/index.md
+        - user-guide/docs/quick_start.md
       - Specification:
           - Basic Structure: user-guide/docs/specification/basic_structure.md
           - API Specification Keys: user-guide/docs/specification/api_specification_keys.md
@@ -27,6 +28,7 @@ nav:
           - Hiding Sensitive Information: user-guide/docs/configuration/hiding_sensitive_information.md
           - ScanAPI CLI: user-guide/docs/configuration/scanapi_cli.md
     - Tutorial:
+      - user-guide/tutorial/index.md
       - Setup: user-guide/tutorial/step01.md
       - API Sign Up: user-guide/tutorial/step02.md
       - Run: user-guide/tutorial/step03.md


### PR DESCRIPTION
You can describe it like this:

### Summary

Improve the User Guide structure by separating the Quick Start content from the documentation index and adding dedicated index pages for both the Docs and Tutorial sections.

### Changes

* Move the **Quick Start** guide from `docs/user-guide/docs/index.md` to its own page (`docs/user-guide/docs/quick_start.md`).
* Simplify `docs/user-guide/docs/index.md` to serve as a navigation page listing all available documentation topics.
* Add a new `docs/user-guide/tutorial/index.md` page with links to every tutorial step.
* Update the User Guide landing page to point to the new Tutorial index instead of linking directly to the first tutorial step.
* Update the MkDocs navigation to:

  * Add a dedicated **Quick Start** page under **Docs**.
  * Add a dedicated **Tutorial** index page before the tutorial steps.

This change improves the documentation organization, makes navigation more consistent, and provides clear entry points for both reference documentation and the step-by-step tutorial.


## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #1027
related to: https://github.com/scanapi/website/pull/110
