### PR TITLE
fix: preserve literal characters surrounding a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Total time delta and response time delta in the HTML report to be more easily human readable
 
 ### Fixed
+- Variables surrounded by word characters, like `/heal${SUFFIX}/`, no longer discard the literal part of the path [#1007](https://github.com/scanapi/scanapi/issues/1007).
 - Non-reachable APIs (NetworkError, TimeoutException) will now exit and report the test as errored [#946](https://github.com/scanapi/scanapi/pull/946).
 
 ## [2.13.2] - 2026-05-18

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -75,7 +75,7 @@ class StringEvaluator:
                 raise BadConfigurationError(e)
 
             sequence = cls.replace_var_with_value(
-                sequence, match.group(), variable_value
+                sequence, cls._variable_token(match), variable_value
             )
 
         return sequence
@@ -111,10 +111,25 @@ class StringEvaluator:
             variable_value = spec_vars.get(variable_name)
 
             sequence = cls.replace_var_with_value(
-                sequence, match.group(), variable_value
+                sequence, cls._variable_token(match), variable_value
             )
 
         return sequence
+
+    @classmethod
+    def _variable_token(cls, match: "re.Match[str]") -> str:
+        """Returns only the ``${<variable>}`` portion of a pattern match.
+
+        The pattern also captures any word characters surrounding the
+        variable, which must not be replaced along with it.
+
+        Args:
+            match (re.Match): a ``variable_pattern`` match
+
+        Returns:
+            string: the ``${<variable>}`` token itself
+        """
+        return f"{match.group('start')}{match.group('variable')}{match.group('end')}"
 
     @classmethod
     def replace_var_with_value(

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -166,6 +166,24 @@ class TestEvaluateCustomVar:
             == expected
         )
 
+    test_data = [
+        ("pos${post_suffix}/", "posts/"),
+        ("/heal${post_suffix}h/", "/healtsh/"),
+        ("${post_suffix}suffix", "tssuffix"),
+    ]
+
+    @mark.context("when matches the pattern")
+    @mark.context("when the variable is surrounded by word characters")
+    @mark.it("should keep the surrounding characters")
+    @mark.parametrize("sequence, expected", test_data)
+    def test_should_keep_surrounding_characters(self, sequence, expected):
+        spec_vars = {"post_suffix": "ts"}
+
+        assert (
+            StringEvaluator._evaluate_custom_var(sequence, spec_vars)
+            == expected
+        )
+
 
 @mark.describe("string evaluator")
 @mark.describe("replace_var_with_value")

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -79,6 +79,24 @@ class TestEvaluateEnvVar:
 
         assert StringEvaluator._evaluate_env_var(sequence) == expected
 
+    test_data = [
+        (
+            "https://jsonplaceholder.typicode.com/pos${POST_SUFFIX}/",
+            "https://jsonplaceholder.typicode.com/posts/",
+        ),
+        ("/heal${POST_SUFFIX}h/", "/healtsh/"),
+        ("${POST_SUFFIX}suffix", "tssuffix"),
+    ]
+
+    @mark.context("when matches the pattern")
+    @mark.context("when the variable is surrounded by word characters")
+    @mark.it("should keep the surrounding characters")
+    @mark.parametrize("sequence, expected", test_data)
+    def test_should_keep_surrounding_characters(self, sequence, expected):
+        os.environ["POST_SUFFIX"] = "ts"
+
+        assert StringEvaluator._evaluate_env_var(sequence) == expected
+
     @mark.context("when matches the pattern")
     @mark.context("when there is no corresponding env var")
     @mark.it("should raise bad configuration error")


### PR DESCRIPTION
## Description
`StringEvaluator.variable_pattern` captures the word characters before and after a `${variable}` (`something_before` / `something_after`), but `_evaluate_env_var` and `_evaluate_custom_var` passed the whole `match.group()` to `replace_var_with_value`. Any literal adjacent to the variable was replaced along with it, so `/heal${PATH_COMPLEMENT}/` with `PATH_COMPLEMENT=th` rendered as `/th/` instead of `/health/`.

Both evaluators now replace only the `${<variable>}` token, leaving the surrounding characters untouched.

## Motivation behind this PR?
Fixes an existing issue: requests are sent to the wrong path when part of a path node is hardcoded and part comes from a variable. This is the pattern generated by `scanapi from openapi`.

## What type of change is this?
Bug Fix

## AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

This change was prepared with AI assistance (Claude); the regression tests were run locally and fail without the fix.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/changelog-guide/)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide/)
- [x] All unit tests pass locally. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide#run)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/first-pull-request/)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/run-scanapi-dev/)

Three parametrized cases were added to `TestEvaluateEnvVar` in `tests/unit/evaluators/test_string_evaluator.py`; they fail on `main` and pass with this change (`36 passed`).

## Issue
Closes #1007
