### PR TITLE
fix(evaluators): preserve surrounding text when replacing env/custom variables

### DIFF
--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -74,8 +74,10 @@ class StringEvaluator:
             except KeyError as e:
                 raise BadConfigurationError(e)
 
+            # Only replace the ${VAR} portion, not surrounding text
+            var_expr = match.group("start") + variable_name + match.group("end")
             sequence = cls.replace_var_with_value(
-                sequence, match.group(), variable_value
+                sequence, var_expr, variable_value
             )
 
         return sequence
@@ -110,8 +112,10 @@ class StringEvaluator:
 
             variable_value = spec_vars.get(variable_name)
 
+            # Only replace the ${VAR} portion, not surrounding text
+            var_expr = match.group("start") + variable_name + match.group("end")
             sequence = cls.replace_var_with_value(
-                sequence, match.group(), variable_value
+                sequence, var_expr, variable_value
             )
 
         return sequence


### PR DESCRIPTION
## Summary

Fix URL rendering bug where environment/custom variables embedded in path segments would incorrectly consume surrounding text.

## Problem

When a request path contains a variable that is part of a larger word (e.g., `/heal${PATH_COMPLEMENT}/`), the rendered URL drops the hardcoded prefix:

```yaml
# scanapi.yaml
path: /heal${PATH_COMPLEMENT}/
# With PATH_COMPLEMENT=th
```

**Expected:** `GET https://demo.scanapi.dev/api/v1/health/`
**Actual (before fix):** `GET https://demo.scanapi.dev/api/v1/th/`

## Root Cause

In `StringEvaluator`, the `variable_pattern` regex captures word characters before ${var} as the `something_before` group. However, `_evaluate_env_var()` and `_evaluate_custom_var()` were passing `match.group()` (the full match including surrounding text) to `replace_var_with_value()`, causing the entire match to be replaced with just the variable value.

## Fix

Changed both methods to pass only the ${var} expression (`match.group('start') + variable_name + match.group('end')`) to `replace_var_with_value()`, preserving any text before or after the variable.

## Testing

- 205 existing tests pass
- 33 string evaluator tests pass (including specific cases for variables surrounded by text)
- Manually verified with the exact reproduction case from #1007

Closes #1007