### PR TITLE
chore: replace deprecated pytest-freezegun with time-machine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pymdown-extensions>=10.21.3,<11.0.0",
     "pytest>=9.0.3,<10.0.0",
     "pytest-cov>=7.0.0,<8.0.0",
-    "pytest-freezegun==0.4.2",  # Unmaintained; strict pin required for stability
+    "time-machine>=2.15,<3.0.0",
     "pytest-it>=0.1.5,<0.2.0",
     "pytest-mock>=3.14.0,<4.0.0",
     "requests-mock>=1.12,<2.0.0",

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -1,6 +1,7 @@
 import pathlib
+from datetime import datetime
 
-from freezegun.api import FakeDatetime
+import time_machine
 from pytest import fixture, mark
 
 from scanapi.reporter import Reporter
@@ -57,7 +58,6 @@ class TestInit:
 
 @mark.describe("reporter")
 @mark.describe("write")
-@mark.freeze_time("2020-05-12 11:32:34")
 class TestWrite:
     @fixture
     def mocked__render(self, mocker):
@@ -78,7 +78,7 @@ class TestWrite:
     @fixture
     def context(self, mocked__session):
         return {
-            "now": FakeDatetime(2020, 5, 12, 11, 32, 34),
+            "now": datetime(2020, 5, 12, 11, 32, 34),
             "project_name": "",
             "results": fake_results,
             "session": mocked__session,
@@ -92,6 +92,7 @@ class TestWrite:
         return mock
 
     @mark.it("should write to default output")
+    @time_machine.travel("2020-05-12 11:32:34")
     def test_should_write_to_default_output(
         self,
         mocked__render,
@@ -111,6 +112,7 @@ class TestWrite:
         mocked__open().write.assert_called_once_with("ScanAPI Report")
 
     @mark.it("should write to custom output")
+    @time_machine.travel("2020-05-12 11:32:34")
     def test_should_write_to_custom_output(
         self,
         mocked__render,
@@ -130,6 +132,7 @@ class TestWrite:
         mocked__open().write.assert_called_once_with("ScanAPI Report")
 
     @mark.it("should handle custom templates")
+    @time_machine.travel("2020-05-12 11:32:34")
     def test_should_handle_custom_templates(
         self,
         mocked__render,
@@ -151,6 +154,7 @@ class TestWrite:
         mocked__open().write.assert_called_once_with("ScanAPI Report")
 
     @mark.it("should open report in browser")
+    @time_machine.travel("2020-05-12 11:32:34")
     def test_should_open_report_in_browser(
         self,
         mocked__render,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,3 +1,4 @@
+import time_machine
 from random import randrange
 
 from pytest import mark, raises
@@ -36,7 +37,7 @@ class TestSucceed:
 @mark.describe("start")
 class TestStart:
     @mark.it("should initialize started_at with current time")
-    @mark.freeze_time("2020-06-15 18:54:57")
+    @time_machine.travel("2020-06-15 18:54:57")
     def test_init_started_at(self):
         session = Session()
 
@@ -108,10 +109,10 @@ class TestIncrementErrors:
 @mark.describe("elapsed_time")
 class TestElapsedTime:
     @mark.it("should return time")
-    @mark.freeze_time("2020-06-15 18:54:57")
-    def test_return_time(self, freezer):
-        session = Session()
+    def test_return_time(self):
+        with time_machine.travel("2020-06-15 18:54:57") as traveller:
+            session = Session()
 
-        freezer.move_to("2020-06-15 18:56:38")
+            traveller.move_to("2020-06-15 18:56:38")
 
-        assert str(session.elapsed_time()) == "0:01:41"
+            assert str(session.elapsed_time()) == "0:01:41"


### PR DESCRIPTION
Fixes #957