### PR TITLE
fix: preserve surrounding text when evaluating dynamic variable paths

### DIFF
--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -74,8 +74,9 @@ class StringEvaluator:
             except KeyError as e:
                 raise BadConfigurationError(e)
 
+            var_expression = match.group("start") + match.group("variable") + match.group("end")
             sequence = cls.replace_var_with_value(
-                sequence, match.group(), variable_value
+                sequence, var_expression, variable_value
             )
 
         return sequence
@@ -110,8 +111,9 @@ class StringEvaluator:
 
             variable_value = spec_vars.get(variable_name)
 
+            var_expression = match.group("start") + match.group("variable") + match.group("end")
             sequence = cls.replace_var_with_value(
-                sequence, match.group(), variable_value
+                sequence, var_expression, variable_value
             )
 
         return sequence
@@ -135,8 +137,5 @@ class StringEvaluator:
             sequence (string): sequence of characters with all occurrences of
             the current variable replaced
         """
-        if variable == sequence:
-            return variable_value
-
-        variable = re.escape(variable)
-        return re.sub(variable, str(variable_value), sequence)
+        escaped = re.escape(variable)
+        return re.sub(escaped, str(variable_value), sequence)

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -119,7 +119,7 @@ class StringEvaluator:
         return sequence
 
     @classmethod
-    def _var_expression(cls, match) -> str:
+    def _var_expression(cls, match: re.Match) -> str:
         """Constructs the variable expression (${var}) from a regex match.
 
         Args:
@@ -128,11 +128,10 @@ class StringEvaluator:
         Returns:
             str: the ${variable} expression to be replaced
         """
-        return (
-            match.group("start")
-            + match.group("variable")
-            + match.group("end")
-        )
+        start = match.group("start")
+        variable = match.group("variable")
+        end = match.group("end")
+        return f"{start}{variable}{end}"
 
     @classmethod
     def replace_var_with_value(

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -74,7 +74,7 @@ class StringEvaluator:
             except KeyError as e:
                 raise BadConfigurationError(e)
 
-            var_expression = match.group("start") + match.group("variable") + match.group("end")
+            var_expression = cls._var_expression(match)
             sequence = cls.replace_var_with_value(
                 sequence, var_expression, variable_value
             )
@@ -111,12 +111,28 @@ class StringEvaluator:
 
             variable_value = spec_vars.get(variable_name)
 
-            var_expression = match.group("start") + match.group("variable") + match.group("end")
+            var_expression = cls._var_expression(match)
             sequence = cls.replace_var_with_value(
                 sequence, var_expression, variable_value
             )
 
         return sequence
+
+    @classmethod
+    def _var_expression(cls, match) -> str:
+        """Constructs the variable expression (${var}) from a regex match.
+
+        Args:
+            match (re.Match): the regex match for the variable pattern
+
+        Returns:
+            str: the ${variable} expression to be replaced
+        """
+        return (
+            match.group("start")
+            + match.group("variable")
+            + match.group("end")
+        )
 
     @classmethod
     def replace_var_with_value(

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -168,7 +168,7 @@ class TestReplaceVarWithValue:
             "https://jsonplaceholder.typicode.com",
             "https://jsonplaceholder.typicode.com/posts",
         ),
-        ("${product_id}", "${product_id}", 100, 100),
+        ("${product_id}", "${product_id}", 100, "100"),
         ("products/${product_id}", "${product_id}", 100, "products/100"),
     ]
 


### PR DESCRIPTION
Fixes #1007

The regex in StringEvaluator was capturing surrounding word characters as part of the match, causing them to be replaced along with the variable value.

For example,  with  would incorrectly render as  instead of .

This fix constructs the variable expression from the regex groups () instead of using the full match, ensuring only the variable itself is replaced.