### PR TITLE
ci: update commands to bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,28 +19,11 @@ check: lint mypy
 
 .PHONY: change-version
 change-version:
-	@current_version=$$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/'); \
-	base_version=$$(echo $$current_version | cut -f-3 -d.); \
-	new_version="$$base_version.dev$(timestamp)"; \
-	sed -i.bak 's/^version = .*/version = "'$$new_version'"/' pyproject.toml && rm pyproject.toml.bak; \
-	echo "Updated version to $$new_version"
-
+	uv version --bump major
 
 .PHONY: change-version-dev
 change-version-dev:
-	@current_version=$$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/'); \
-	base_version=$$(echo $$current_version | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/'); \
-	release_version=$$(echo $$base_version | awk -F. '{printf "%d.%d.%d", $$1, $$2, $$3 + 1}'); \
-	commit_count=$$(repo=$$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true); \
-	if [ -n "$$repo" ]; then \
-		gh api "repos/$$repo/compare/$$base_version...HEAD" --jq '.ahead_by' 2>/dev/null || echo 0; \
-	else \
-		echo 0; \
-	fi); \
-	new_version="$$release_version.dev$$commit_count"; \
-	sed -i.bak 's/^version = .*/version = "'$$new_version'"/' pyproject.toml && rm pyproject.toml.bak; \
-	echo "Updated version to $$new_version"
-
+	uv version --bump patch --bump dev
 .PHONY: format
 format:
 	@uv run ruff check --fix .


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Update commands to bump versions, avoiding uploading two versions with the same numbering. Now, the bump is made by UV commands, reducing command complexity and keeping the same version format
## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
#1048 
## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Bug fix.
## AI Assistance Disclosure (REQUIRED)
- [ x] No AI tools were used in preparing this PR.
- [ ] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [ x] A changelog entry was added, or this PR does not require one. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/changelog-guide/)
- [ x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide/)
- [ x] All unit tests pass locally. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide#run)
- [ x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/first-pull-request/)
- [ x] This PR does not significantly reduce code or docstring coverage.
- [ x] Code follows the project’s style guidelines.
- [ x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/run-scanapi-dev/)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #1048 