### PR TITLE
ci: update publish-dev workflow trigger to run after merging

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,7 +1,8 @@
 name: Publish dev
 
 on:
-  push:
+  pull_request:
+    types: closed
     branches:
       - main
 permissions:
@@ -10,7 +11,7 @@ permissions:
 
 jobs:
   build-n-publish-pypi:
-    if: github.repository == 'scanapi/scanapi'
+    if: github.repository == 'scanapi/scanapi' && github.event.pull_request.merged == true
     name:  Build and publish Python 🐍 distributions 📦
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
This PR updates the publish-dev workflow trigger to run after merging, ensuring the `dev` version update is based on main instead of the issue branch, therefore avoiding version conflicts.

## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->
#1053 
## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->
Bug fix.
## AI Assistance Disclosure (REQUIRED)
- [ x] No AI tools were used in preparing this PR.
- [ ] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [ x] A changelog entry was added, or this PR does not require one. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/changelog-guide/)
- [ x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide/)
- [ x] All unit tests pass locally. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide#run)
- [ x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/first-pull-request/)
- [ x] This PR does not significantly reduce code or docstring coverage.
- [ x] Code follows the project’s style guidelines.
- [ x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/run-scanapi-dev/)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #1053 