### PR TITLE
ci: increment dev version based on tags

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -2,50 +2,80 @@ name: Publish dev
 
 on:
   pull_request:
-    types: closed
+  push:
     branches:
       - main
+
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
+
+concurrency:
+  group: publish-dev
+  cancel-in-progress: false
 
 jobs:
   build-n-publish-pypi:
-    if: github.repository == 'scanapi/scanapi' && github.event.pull_request.merged == true
-    name:  Build and publish Python 🐍 distributions 📦
+    name: Build and publish Python 🐍 distributions 📦
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.6.0
         with:
           python-version: 3.12.x
+
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b #v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
+
       - name: Install Dependencies
         run: uv sync --extra dev --prerelease=allow
-      - name: Run pre-release version update
-        run: |
-          make change-version-dev
-      - name: Build and publish to pypi
+
+      - name: Set development version
+        run: make bump-dev-version
+
+      - name: Get development version
+        id: version
+        run: echo "version=$(uv version --short)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish to PyPI
         run: |
           uv build
           uv publish --token ${{ secrets.PYPI_TOKEN }}
+
+      - name: Create development tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
   test-examples:
     name: Test Examples
     runs-on: ubuntu-latest
     needs:
       - build-n-publish-pypi
+
     steps:
       - name: Checkout ScanAPI repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Install dev version of ScanAPI
-        run: pip install "scanapi==$(uv version)"
+        run: pip install "scanapi==${{ needs.build-n-publish-pypi.outputs.version }}"
+
       - name: Run examples
         uses: ./.github/actions/run_examples_suite
- 

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,40 @@ mypy:
 .PHONY: check
 check: lint mypy
 
-.PHONY: change-version
-change-version:
-	uv version --bump major
+.PHONY: bump-major-version
+bump-major-version:
+	@uv version --bump major
 
-.PHONY: change-version-dev
-change-version-dev:
-	uv version --bump patch --bump dev
+# Calculate the next development version from Git tags.
+#
+# Examples:
+#   v2.13.2 + no dev tags        -> 2.13.3.dev0
+#   v2.13.2 + v2.13.3.dev0       -> 2.13.3.dev1
+#   v2.13.2 + v2.13.3.dev46      -> 2.13.3.dev47
+#
+# The stable release determines the next patch version, while the latest
+# development tag determines the development release number.
+.PHONY: next-dev-version
+next-dev-version:
+	@last_release=$$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -n 1); \
+	test -n "$$last_release" || { echo "No stable release tag found" >&2; exit 1; }; \
+	base_version=$${last_release#v}; \
+	next_version=$$(echo "$$base_version" | awk -F. '{print $$1 "." $$2 "." ($$3 + 1)}'); \
+	last_dev=$$(git tag --list "v$${next_version}.dev*" --sort=-v:refname | head -n 1); \
+	if [ -z "$$last_dev" ]; then \
+		dev_number=0; \
+	else \
+		dev_number=$$(echo "$$last_dev" | sed -E 's/.*\.dev([0-9]+)$$/\1/'); \
+		dev_number=$$((dev_number + 1)); \
+	fi; \
+	echo "$${next_version}.dev$$dev_number"
+
+.PHONY: bump-dev-version
+bump-dev-version:
+	@version=$$(make --no-print-directory next-dev-version); \
+	echo "Setting development version to $$version"; \
+	uv version "$$version"
+
 .PHONY: format
 format:
 	@uv run ruff check --fix .


### PR DESCRIPTION
## Description

This PR updates the development versioning flow to automatically increment pre-release versions based on Git tags.

Previously, development versions were bumped directly with `uv version --bump patch --bump dev`. This could cause the version number to be reset or duplicated across development releases.

This changes the flow to:

* Use the latest stable release tag to determine the next patch version.
* Use the latest development tag to determine the next `.devN` number.
* Create a Git tag for each development release.
* Use the generated version for both the PyPI package and Git tag.
* Add workflow concurrency to prevent concurrent releases from generating the same version.
* Trigger development releases on pushes to `main`.

Examples:

```text
v2.13.2 + no dev tags       → 2.13.3.dev0
v2.13.2 + v2.13.3.dev0      → 2.13.3.dev1
v2.13.2 + v2.13.3.dev46     → 2.13.3.dev47
```

This makes Git tags the source of truth for development version tracking and keeps the versioning logic in the `Makefile`.


## Motivation behind this PR?
<!--- Why is the change required? Does it fix an existing issue, please link the issue. -->

## What type of change is this?
<!--- Bug Fix or Feature or Breaking Change i.e fix or feature that would cause existing functionality to not work as expected -->

## AI Assistance Disclosure (REQUIRED)
- [ ] No AI tools were used in preparing this PR.
- [x] If AI tools were used, I have disclosed which ones, and fully reviewed and verified their output.

## Checklist
<!-- Please evaluate each item and mark all checkboxes. -->

- [x] A changelog entry was added, or this PR does not require one. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/changelog-guide/)
- [x] Unit tests were added or updated as needed, or not required for this change. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide/)
- [x] All unit tests pass locally. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/tests-guide#run)
- [x] Docstrings or comments were added or updated as needed, or no documentation changes were required. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/first-pull-request/)
- [x] This PR does not significantly reduce code or docstring coverage.
- [x] Code follows the project’s style guidelines.
- [x] ScanAPI was run locally and the changes were manually verified, or this was not necessary. [Instructions](https://scanapi.readthedocs.io/en/latest/contributor-guide/run-scanapi-dev/)

## Issue
<!--- All PRs must have a related issue. This way we can ensure that no one loses time working in something that does not needed to be done. -->
Closes #1055 
