### PR TITLE
chore(release): 2.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+## [2.13.3] - 2026-08-12
 ### Changed
 - Changed standard report template so it groups requests by top level endpoints in a collapsible [#951](https://github.com/scanapi/scanapi/pull/951).
 
-### Changed
-- Update Total time delta and response time delta in the HTML report to be more easily human readable
+- Update Total time delta and response time delta in the HTML report to be more easily human readable [#927](https://github.com/scanapi/scanapi/pull/927).
 
 ### Fixed
 - Non-reachable APIs (NetworkError, TimeoutException) will now exit and report the test as errored [#946](https://github.com/scanapi/scanapi/pull/946).
@@ -325,7 +324,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix vars interpolation.
 
-[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.13.2...HEAD
+[Unreleased]: https://github.com/scanapi/scanapi/compare/v2.13.3...HEAD
+[2.13.3]: https://github.com/scanapi/scanapi/compare/v2.13.2...v2.13.3
 [2.13.2]: https://github.com/scanapi/scanapi/compare/v2.13.1...v2.13.2
 [2.13.1]: https://github.com/scanapi/scanapi/compare/v2.13.0...v2.13.1
 [2.13.0]: https://github.com/scanapi/scanapi/compare/v2.12.0...v2.13.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="~/.local/bin:${PATH}"
 
 RUN pip install pip setuptools --upgrade
 
-RUN python -m pip install --no-cache-dir scanapi==2.13.2
+RUN python -m pip install --no-cache-dir scanapi==2.13.3
 
 COPY . /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scanapi"
-version = "2.13.2"
+version = "2.13.3"
 description = "Automated Testing and Documentation for your REST API"
 authors = [{name = "The ScanAPI Organization", email = "cmaiacd@gmail.com"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1654,7 +1654,7 @@ wheels = [
 
 [[package]]
 name = "scanapi"
-version = "2.13.2"
+version = "2.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
### Changed
- Changed standard report template so it groups requests by top level endpoints in a collapsible [#951](https://github.com/scanapi/scanapi/pull/951).

- Update Total time delta and response time delta in the HTML report to be more easily human readable [#927](https://github.com/scanapi/scanapi/pull/927).

### Fixed
- Non-reachable APIs (NetworkError, TimeoutException) will now exit and report the test as errored [#946](https://github.com/scanapi/scanapi/pull/946).

