### PR TITLE
fix: support disabling HTTPS verification

### DIFF
--- a/scanapi/utils.py
+++ b/scanapi/utils.py
@@ -89,5 +89,7 @@ def session_with_retry(
     retries = retry_configuration.get(MAX_RETRIES_KEY, 0)
 
     return Client(
-        transport=HTTPTransport(retries=retries), timeout=None, verify=verify
+        transport=HTTPTransport(retries=retries, verify=verify),
+        timeout=None,
+        verify=verify,
     )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,5 @@
+import ssl
+
 import requests
 from pytest import fixture, mark, raises
 
@@ -123,3 +125,23 @@ class TestSessionWithRetry:
         session = session_with_retry({"max_retries": 7})
 
         assert session._transport._pool._retries == 7
+
+    @mark.context("default verify parameter")
+    @mark.it("should enable certificate verification by default")
+    def test_default_verify_is_true(self):
+        session = session_with_retry({})
+
+        assert (
+            session._transport._pool._ssl_context.verify_mode
+            == ssl.CERT_REQUIRED
+        )
+
+    @mark.context("verify is False")
+    @mark.it("should disable certificate verification")
+    def test_verify_false(self):
+        session = session_with_retry({}, verify=False)
+
+        assert (
+            session._transport._pool._ssl_context.verify_mode
+            == ssl.CERT_NONE
+        )

--- a/tests/unit/tree/request_node/test_run.py
+++ b/tests/unit/tree/request_node/test_run.py
@@ -22,10 +22,39 @@ class TestRun:
     def mock_console_write_result(self, mocker):
         return mocker.patch("scanapi.tree.request_node.write_result")
 
-    @mark.skip("should call session_with_retry with retry and verify")
-    def test_call_session_with_retry(self):
-        # TODO
-        pass
+    @mark.it("should call session_with_retry with retry and verify")
+    def test_call_session_with_retry(
+        self, mock_session_with_retry, mock_time_sleep
+    ):
+        request = RequestNode(
+            {
+                "path": "http://foo.com",
+                "name": "request_name",
+                "options": {"verify": False},
+                "retry": {"max_retries": 3},
+            },
+            endpoint=EndpointNode({"name": "endpoint_name", "requests": []}),
+        )
+        request.run()
+
+        mock_session_with_retry.assert_called_once_with(
+            {"max_retries": 3}, False
+        )
+
+    @mark.it("should call session_with_retry with default verify as True")
+    def test_call_session_with_retry_default_verify(
+        self, mock_session_with_retry, mock_time_sleep
+    ):
+        request = RequestNode(
+            {
+                "path": "http://foo.com",
+                "name": "request_name",
+            },
+            endpoint=EndpointNode({"name": "endpoint_name", "requests": []}),
+        )
+        request.run()
+
+        mock_session_with_retry.assert_called_once_with(None, True)
 
     @mark.it("should call the request method")
     def test_calls_request(self, mock_session_with_retry, mock_time_sleep):


### PR DESCRIPTION
## Description

Fixes HTTPS verification handling when `verify: false` is explicitly configured.

The request-level `verify` option was already parsed by ScanAPI but was not forwarded to the underlying `httpx.HTTPTransport`, causing certificate verification to remain enabled.

The fix forwards the `verify` value to `HTTPTransport` while preserving secure verification by default.

## Related Issue

Fixes #1018

## Testing

- 39 targeted tests passed
- 393 tests passed in the full test suite
- Ruff checks passed

Two existing Windows-specific path assertion failures are unrelated to this change.