### PR TITLE
fix: correct dynamic URL rendering

### DIFF
--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -14,11 +14,7 @@ class CodeEvaluator:
     # Configuration: modules available in API spec evaluation
     ALLOWED_MODULES = ["datetime", "math", "random", "re", "time", "uuid"]
     python_code_pattern = re.compile(
-        r"(?P<something_before>\w*)"
-        r"(?P<start>\${{)"
-        r"(?P<python_code>.*)"
-        r"(?P<end>}})"
-        r"(?P<something_after>\w*)"
+        r"\${{(?P<python_code>.*)}}"
     )  # ${{<python_code>}}
 
     @classmethod

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -14,11 +14,7 @@ class StringEvaluator:
     """
 
     variable_pattern = re.compile(
-        r"(?P<something_before>\w*)"
-        r"(?P<start>\${)"
-        r"(?P<variable>[\w|-]*)"
-        r"(?P<end>})"
-        r"(?P<something_after>\w*)"
+        r"\${(?P<variable>[\w-]*)}"
     )  # ${<variable>}
 
     @classmethod

--- a/tests/unit/evaluators/test_code_evaluator.py
+++ b/tests/unit/evaluators/test_code_evaluator.py
@@ -88,7 +88,12 @@ class TestEvaluate:
 
         assert isinstance(excinfo.value, InvalidPythonCodeError)
 
-    test_data = [("${{1 + 1}}", "2"), ("${{'hi'*4}}", "hihihihi")]
+    test_data = [
+        ("${{1 + 1}}", "2"),
+        ("${{'hi'*4}}", "hihihihi"),
+        ("prefix_${{1 + 1}}_suffix", "prefix_2_suffix"),
+        ("/api/v${{1 + 1}}/users", "/api/v2/users"),
+    ]
 
     @mark.context("when sequence matches the pattern")
     @mark.context("when it is not a test case")

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -67,15 +67,19 @@ class TestEvaluateEnvVar:
             "${BASE_URL}/posts/${POST_ID}",
             "https://jsonplaceholder.typicode.com/posts/2",
         ),
+        ("/heal${PATH_COMPLEMENT}/", "/health/"),
+        ("${PATH_COMPLEMENT}extra", "thextra"),
+        ("/heal${PATH_COMPLEMENT}extra/", "/healthextra/"),
     ]
 
     @mark.context("when matches the pattern")
     @mark.context("when env var is set properly")
     @mark.it("should return sequence with evaluated var")
     @mark.parametrize("sequence, expected", test_data)
-    def test_should_return_evaluated_var(self, sequence, expected):
-        os.environ["BASE_URL"] = "https://jsonplaceholder.typicode.com"
-        os.environ["POST_ID"] = "2"
+    def test_should_return_evaluated_var(self, monkeypatch, sequence, expected):
+        monkeypatch.setenv("BASE_URL", "https://jsonplaceholder.typicode.com")
+        monkeypatch.setenv("POST_ID", "2")
+        monkeypatch.setenv("PATH_COMPLEMENT", "th")
 
         assert StringEvaluator._evaluate_env_var(sequence) == expected
 
@@ -131,6 +135,8 @@ class TestEvaluateCustomVar:
             "something before 10 something after",
         ),
         ("${user_id} something after", "10 something after"),
+        ("/heal${path_complement}/", "/health/"),
+        ("prefix${user_id}suffix", "prefix10suffix"),
     ]
 
     @mark.context("when matches the pattern")
@@ -142,6 +148,7 @@ class TestEvaluateCustomVar:
             "user_id": "10",
             "apiKey": "abc123",
             "api-token": "xwo",
+            "path_complement": "th",
         }
         assert (
             StringEvaluator._evaluate_custom_var(sequence, spec_vars)

--- a/tests/unit/tree/request_node/test_full_path_url.py
+++ b/tests/unit/tree/request_node/test_full_path_url.py
@@ -84,6 +84,23 @@ class TestFullPathUrl:
         )
         assert request.full_url_path == "http://foo.com/foo-bar"
 
+    @mark.context(
+        "when the request specification has a URL with literal text before an environment variable"
+    )
+    @mark.it(
+        "should set the full url path substituting the environment variable and preserving the literal prefix"
+    )
+    def test_with_path_literal_prefix_and_env_var(self, monkeypatch):
+        monkeypatch.setenv("PATH_COMPLEMENT", "th")
+        endpoint = EndpointNode(
+            {"name": "foo", "requests": [{}], "path": "http://foo.com/api"}
+        )
+        request = RequestNode(
+            {"name": "foo", "path": "/heal${PATH_COMPLEMENT}/"},
+            endpoint=endpoint,
+        )
+        assert request.full_url_path == "http://foo.com/api/health/"
+
     @mark.it("should call the evaluate method")
     def test_calls_evaluate(self, mocker, mock_evaluate):
         endpoint = EndpointNode(


### PR DESCRIPTION
## Summary

Fix dynamic URL rendering when variables or Python expressions are surrounded by literal text.

## Changes

- Corrected variable and Python expression matching so surrounding literal URL text is preserved.
- Added tests for prefixes and suffixes around dynamic variables and expressions.
- Added request URL integration coverage.

## Testing

- `uv run pytest tests/unit/evaluators/ tests/unit/tree/request_node/test_full_path_url.py`
- `uv run ruff check scanapi tests`
- `git diff --check`