### PR TITLE
fix: support disabling HTTPS verification

### DIFF
--- a/scanapi/utils.py
+++ b/scanapi/utils.py
@@ -89,5 +89,7 @@ def session_with_retry(
     retries = retry_configuration.get(MAX_RETRIES_KEY, 0)
 
     return Client(
-        transport=HTTPTransport(retries=retries), timeout=None, verify=verify
+        transport=HTTPTransport(retries=retries, verify=verify),
+        timeout=None,
+        verify=verify,
     )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -123,3 +123,30 @@ class TestSessionWithRetry:
         session = session_with_retry({"max_retries": 7})
 
         assert session._transport._pool._retries == 7
+
+    @mark.context("verify is not provided")
+    @mark.it("should enable HTTPS certificate verification by default")
+    def test_verify_default(self):
+        import ssl
+
+        session = session_with_retry({})
+
+        assert session._transport._pool._ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+    @mark.context("verify=True is provided explicitly")
+    @mark.it("should enable HTTPS certificate verification")
+    def test_verify_true(self):
+        import ssl
+
+        session = session_with_retry({}, verify=True)
+
+        assert session._transport._pool._ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+    @mark.context("verify=False is provided explicitly")
+    @mark.it("should disable HTTPS certificate verification")
+    def test_verify_false(self):
+        import ssl
+
+        session = session_with_retry({}, verify=False)
+
+        assert session._transport._pool._ssl_context.verify_mode == ssl.CERT_NONE

--- a/tests/unit/tree/request_node/test_run.py
+++ b/tests/unit/tree/request_node/test_run.py
@@ -22,10 +22,58 @@ class TestRun:
     def mock_console_write_result(self, mocker):
         return mocker.patch("scanapi.tree.request_node.write_result")
 
-    @mark.skip("should call session_with_retry with retry and verify")
-    def test_call_session_with_retry(self):
-        # TODO
-        pass
+    @mark.context("when options has verify=False")
+    @mark.it("should call session_with_retry with verify=False")
+    def test_call_session_with_retry_verify_false(
+        self, mock_session_with_retry, mock_time_sleep
+    ):
+        request = RequestNode(
+            {
+                "path": "http://foo.com",
+                "name": "request_name",
+                "options": {"verify": False},
+            },
+            endpoint=EndpointNode(
+                {"name": "endpoint_name", "requests": [{}]}
+            ),
+        )
+        request.run()
+
+        mock_session_with_retry.assert_called_with(request.retry, False)
+
+    @mark.context("when options has verify=True")
+    @mark.it("should call session_with_retry with verify=True")
+    def test_call_session_with_retry_verify_true(
+        self, mock_session_with_retry, mock_time_sleep
+    ):
+        request = RequestNode(
+            {
+                "path": "http://foo.com",
+                "name": "request_name",
+                "options": {"verify": True},
+            },
+            endpoint=EndpointNode(
+                {"name": "endpoint_name", "requests": [{}]}
+            ),
+        )
+        request.run()
+
+        mock_session_with_retry.assert_called_with(request.retry, True)
+
+    @mark.context("when no verify option is set")
+    @mark.it("should call session_with_retry with verify=True by default")
+    def test_call_session_with_retry_verify_default(
+        self, mock_session_with_retry, mock_time_sleep
+    ):
+        request = RequestNode(
+            {"path": "http://foo.com", "name": "request_name"},
+            endpoint=EndpointNode(
+                {"name": "endpoint_name", "requests": [{}]}
+            ),
+        )
+        request.run()
+
+        mock_session_with_retry.assert_called_with(request.retry, True)
 
     @mark.it("should call the request method")
     def test_calls_request(self, mock_session_with_retry, mock_time_sleep):


### PR DESCRIPTION
## Summary

Fix HTTPS certificate verification handling so the configured `verify` option is correctly propagated to the HTTP transport.

## Changes

- Preserve HTTPS certificate verification by default.
- Correctly propagate `verify=False` when explicitly configured.
- Add regression tests for enabled and disabled verification behavior.
- Keep the change scoped to the request/session configuration path.

## Testing

- `uv run pytest`
- `uv run ruff check scanapi tests`
- `git diff --check`

Full test suite: 395 passed, 2 pre-existing Windows path-separator failures.
Focused tests: 34 passed.